### PR TITLE
Refactor: Use injection to create web layouts

### DIFF
--- a/glue.json
+++ b/glue.json
@@ -4,6 +4,8 @@
   "require" : {
     "xp-framework/xml"   : "~6.0",
     "xp-framework/http"  : "~6.0",
-    "xp-framework/rdbms" : "~6.0"
+    "xp-framework/rdbms" : "~6.0",
+    "xp-framework/mail"  : "~6.0",
+    "xp-forge/inject"    : ">=0.1"
   }
 }

--- a/glue.json
+++ b/glue.json
@@ -6,6 +6,6 @@
     "xp-framework/http"  : "~6.0",
     "xp-framework/rdbms" : "~6.0",
     "xp-framework/mail"  : "~6.0",
-    "xp-forge/inject"    : ">=0.1"
+    "xp-forge/inject"    : ">=0.3"
   }
 }

--- a/src/main/php/xp/scriptlet/CompositeLayout.class.php
+++ b/src/main/php/xp/scriptlet/CompositeLayout.class.php
@@ -1,0 +1,49 @@
+<?php namespace xp\scriptlet;
+
+/**
+ * Web application configuration
+ *
+ * @see   xp://xp.scriptlet.WebApplication
+ */
+class CompositeLayout extends \lang\Object implements WebLayout {
+  protected $layouts= [];
+
+  /**
+   * Creates a new composite layout
+   *
+   * @param  xp.scriptlet.WebLayout[] $layout
+   */
+  public function __construct($layouts) {
+    $this->layouts= $layouts;
+  }
+
+
+  /**
+   * Gets all mapped applications
+   *
+   * @param   string profile
+   * @return  [:xp.scriptlet.WebApplication]
+   * @throws  lang.IllegalStateException if the web is misconfigured
+   */
+  public function mappedApplications($profile= null) {
+    $merged= [];
+    foreach ($this->layouts as $layout) {
+      $merged= array_merge($merged, $layout->mappedApplications($profile));
+    }
+    return $merged;
+  }
+
+  /**
+   * Gets all static resources
+   *
+   * @param   string profile
+   * @return  [:string]
+   */
+  public function staticResources($profile= null) {
+    $merged= [];
+    foreach ($this->layouts as $layout) {
+      $merged= array_merge($merged, $layout->staticResources($profile));
+    }
+    return $merged;
+  }
+}

--- a/src/main/php/xp/scriptlet/WebConfiguration.class.php
+++ b/src/main/php/xp/scriptlet/WebConfiguration.class.php
@@ -9,7 +9,7 @@ use util\Hashmap;
  * @see   xp://xp.scriptlet.WebApplication
  * @test  xp://scriptlet.unittest.WebConfigurationTest
  */
-class WebConfiguration extends \lang\Object {
+class WebConfiguration extends \lang\Object implements WebLayout {
   protected $prop= null;
   
   /**

--- a/src/main/php/xp/scriptlet/WebLayout.class.php
+++ b/src/main/php/xp/scriptlet/WebLayout.class.php
@@ -1,0 +1,24 @@
+<?php namespace xp\scriptlet;
+
+/**
+ * Web application configuration
+ */
+interface WebLayout {
+
+  /**
+   * Gets all mapped applications
+   *
+   * @param   string profile
+   * @return  [:xp.scriptlet.WebApplication]
+   * @throws  lang.IllegalStateException if the web is misconfigured
+   */
+  public function mappedApplications($profile= null);
+
+  /**
+   * Gets all static resources
+   *
+   * @param   string profile
+   * @return  [:string]
+   */
+  public function staticResources($profile= null);
+}

--- a/src/main/php/xp/scriptlet/WebModule.class.php
+++ b/src/main/php/xp/scriptlet/WebModule.class.php
@@ -1,0 +1,24 @@
+<?php namespace xp\scriptlet;
+
+abstract class WebModule extends \lang\reflect\Module {
+  public static $loaded= [];
+
+  /**
+   * Initialize this module
+   */
+  public function initialize() {
+    self::$loaded[]= $this;
+  }
+
+  /** @return xp.scriptlet.WebLayout */
+  protected abstract function webLayout();
+
+  /**
+   * Bind
+   *
+   * @param  inject.Injector $inject
+   */
+  public function bind($inject) {
+    $inject->bind('xp.scriptlet.WebLayout', $this->webLayout());
+  }
+}

--- a/src/main/php/xp/scriptlet/WebModule.class.php
+++ b/src/main/php/xp/scriptlet/WebModule.class.php
@@ -11,14 +11,6 @@ abstract class WebModule extends \lang\reflect\Module {
   }
 
   /** @return xp.scriptlet.WebLayout */
-  protected abstract function webLayout();
+  public abstract function layout();
 
-  /**
-   * Bind
-   *
-   * @param  inject.Injector $inject
-   */
-  public function bind($inject) {
-    $inject->bind('xp.scriptlet.WebLayout', $this->webLayout());
-  }
 }


### PR DESCRIPTION
This pull request changes the scriptlet infrastructure to use dependency injection to create web layouts - the configuration of  URLs and their mappings to applications and static resources. This is achieved with a dependency on [xp-forge/inject](https://github.com/xp-forge/inject).
