### PR TITLE
Web config

### DIFF
--- a/src/main/php/xp/scriptlet/BasedOnWebroot.class.php
+++ b/src/main/php/xp/scriptlet/BasedOnWebroot.class.php
@@ -12,16 +12,18 @@ use io\Path;
  * @see   xp://xp.scriptlet.WebApplication
  */
 class BasedOnWebroot extends \lang\Object implements WebLayout {
-  private $webroot;
+  private $webroot, $config;
   private $layout= null;
 
   /**
    * Creates a new instance
    *
    * @param  io.Path $webroot
+   * @param  xp.scriptlet.Config $config
    */
-  public function __construct(Path $webroot) {
+  public function __construct(Path $webroot, Config $config= null) {
     $this->webroot= $webroot;
+    $this->config= $config;
   }
 
   /**
@@ -33,7 +35,7 @@ class BasedOnWebroot extends \lang\Object implements WebLayout {
     if (null === $this->layout) {
       $ini= new Path($this->webroot, 'etc', WebConfiguration::INI);
       if ($ini->exists()) {
-        $this->layout= new WebConfiguration(new Properties($ini->toString()));
+        $this->layout= new WebConfiguration(new Properties($ini->toString()), $this->config);
       } else {
         $this->layout= new ServeDocumentRootStatically();
       }

--- a/src/main/php/xp/scriptlet/Config.class.php
+++ b/src/main/php/xp/scriptlet/Config.class.php
@@ -12,16 +12,16 @@ use lang\ElementNotFoundException;
  * config sources; implicitely searching either `./etc` or `.` for property
  * files. The `properties()` method then searches these locations.
  */
-class Config {
+class Config implements \lang\Value {
   private $sources= [];
 
   /**
    * Creates a new config instance from given sources
    *
-   * @param  (string|util.PropertySource)... $source
+   * @param  string[]|util.PropertySource[] $sources
    */
-  public function __construct() {
-    foreach (func_get_args() as $source) {
+  public function __construct($sources= []) {
+    foreach ($sources as $source) {
       $this->append($source);
     }
   }
@@ -74,5 +74,25 @@ class Config {
       case 1: return $found[0];
       default: return new CompositeProperties($found);
     }
+  }
+
+  /**
+   * Compares a value to this config instance
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->sources, $value->sources) : 1;
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'C'.Objects::hashOf($this->sources);
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).Objects::stringOf($this->sources);
   }
 }

--- a/src/main/php/xp/scriptlet/Config.class.php
+++ b/src/main/php/xp/scriptlet/Config.class.php
@@ -1,0 +1,78 @@
+<?php namespace xp\scriptlet;
+
+use util\PropertySource;
+use util\FilesystemPropertySource;
+use util\ResourcePropertySource;
+use util\CompositeProperties;
+use util\Objects;
+use lang\ElementNotFoundException;
+
+/**
+ * The command line for any command allows specifiy explicit ("-c [source]")
+ * config sources; implicitely searching either `./etc` or `.` for property
+ * files. The `properties()` method then searches these locations.
+ */
+class Config {
+  private $sources= [];
+
+  /**
+   * Creates a new config instance from given sources
+   *
+   * @param  (string|util.PropertySource)... $source
+   */
+  public function __construct() {
+    foreach (func_get_args() as $source) {
+      $this->append($source);
+    }
+  }
+
+  /**
+   * Appends property source
+   *
+   * @param  string|util.PropertySource $source
+   * @return void
+   */
+  public function append($source) {
+    if ($source instanceof PropertySource) {
+      $this->sources[]= $source;
+    } else if (is_dir($source)) {
+      $this->sources[]= new FilesystemPropertySource($source);
+    } else if (0 === strncmp('res://', $source, 6)) {
+      $this->sources[]= new ResourcePropertySource(substr($source, 6));
+    } else {
+      $this->sources[]= new ResourcePropertySource($source);
+    }
+  }
+
+  /** @retun bool */
+  public function isEmpty() { return empty($this->sources); }
+
+  /** @return util.PropertySource[] */
+  public function sources() { return $this->sources; }
+
+  /**
+   * Gets properties
+   *
+   * @param  string $name
+   * @return util.PropertyAccess
+   * @throws lang.ElementNotFoundException
+   */
+  public function properties($name) {
+    $found= [];
+    foreach ($this->sources as $source) {
+      if ($source->provides($name)) {
+        $found[]= $source->fetch($name);
+      }
+    }
+
+    switch (sizeof($found)) {
+      case 0: throw new ElementNotFoundException(sprintf(
+        'Cannot find properties "%s" in any of %s',
+        $name,
+        Objects::stringOf($this->sources)
+      ));
+      case 1: return $found[0];
+      default: return new CompositeProperties($found);
+    }
+  }
+}

--- a/src/main/php/xp/scriptlet/Config.class.php
+++ b/src/main/php/xp/scriptlet/Config.class.php
@@ -6,11 +6,14 @@ use util\ResourcePropertySource;
 use util\CompositeProperties;
 use util\Objects;
 use lang\ElementNotFoundException;
+new import('lang.ResourceProvider');
 
 /**
  * The command line for any command allows specifiy explicit ("-c [source]")
  * config sources; implicitely searching either `./etc` or `.` for property
  * files. The `properties()` method then searches these locations.
+ *
+ * @test  xp://scriptlet.unittest.ConfigTest
  */
 class Config implements \lang\Value {
   private $sources= [];
@@ -35,10 +38,10 @@ class Config implements \lang\Value {
   public function append($source) {
     if ($source instanceof PropertySource) {
       $this->sources[]= $source;
-    } else if (is_dir($source)) {
-      $this->sources[]= new FilesystemPropertySource($source);
     } else if (0 === strncmp('res://', $source, 6)) {
       $this->sources[]= new ResourcePropertySource(substr($source, 6));
+    } else if (is_dir($source)) {
+      $this->sources[]= new FilesystemPropertySource($source);
     } else {
       $this->sources[]= new ResourcePropertySource($source);
     }

--- a/src/main/php/xp/scriptlet/Config.class.php
+++ b/src/main/php/xp/scriptlet/Config.class.php
@@ -7,6 +7,7 @@ use util\CompositeProperties;
 use util\Objects;
 use lang\ElementNotFoundException;
 use lang\FunctionType;
+use lang\Primitive;
 new import('lang.ResourceProvider');
 
 /**
@@ -22,7 +23,7 @@ class Config implements \lang\Value {
   private $sources= [];
 
   static function __static() {
-    self::$expansion= new FunctionType(['string'], 'string');
+    self::$expansion= new FunctionType([Primitive::$STRING], Primitive::$STRING);
   }
 
   /**

--- a/src/main/php/xp/scriptlet/Config.class.php
+++ b/src/main/php/xp/scriptlet/Config.class.php
@@ -47,7 +47,7 @@ class Config implements \lang\Value {
     }
   }
 
-  /** @retun bool */
+  /** @return bool */
   public function isEmpty() { return empty($this->sources); }
 
   /** @return util.PropertySource[] */

--- a/src/main/php/xp/scriptlet/Config.class.php
+++ b/src/main/php/xp/scriptlet/Config.class.php
@@ -109,6 +109,6 @@ class Config implements \lang\Value {
 
   /** @return string */
   public function toString() {
-    return nameof($this).Objects::stringOf($this->sources);
+    return nameof($this).($this->sources ? Objects::stringOf($this->sources) : '[]');
   }
 }

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -10,7 +10,8 @@ use scriptlet\HttpScriptlet;
 use scriptlet\HttpScriptletRequest;
 use scriptlet\HttpScriptletResponse;
 use peer\http\HttpConstants;
-use lang\XPClass;
+use lang\IllegalStateException;
+new import('lang.ResourceProvider');
 
 /**
  * Scriptlet runner
@@ -24,7 +25,6 @@ class Runner extends \lang\Object {
     $mappings   = null;
 
   static function __static() {
-    XPClass::forName('lang.ResourceProvider');
     if (!function_exists('getallheaders')) {
       eval('function getallheaders() {
         $headers= [];
@@ -186,7 +186,9 @@ class Runner extends \lang\Object {
     $instance= null;
     $e= null;
     try {
-      $class= \lang\XPClass::forName($application->scriptlet());
+      if (!($class= $application->scriptlet())) {
+        throw new IllegalStateException('No scriptlet in '.$application->toString());
+      }
       if (!$class->hasConstructor()) {
         $instance= $class->newInstance();
       } else {

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -141,18 +141,19 @@ class Runner extends \lang\Object {
 
   /**
    * Expand variables in string. Handles the following placeholders:
-   * <ul>
-   *   <li>WEBROOT</li>
-   *   <li>PROFILE</li>
-   * </ul>
+   *
+   * - WEBROOT
+   * - PROFILE
+   * - DOCUMENT_ROOT
    *
    * @param  string $value
    * @return string
    */
   public function expand($value) {
     return is_string($value) ? strtr($value, [
-      '{WEBROOT}' => $this->webroot,
-      '{PROFILE}' => $this->profile
+      '{WEBROOT}'       => $this->webroot,
+      '{PROFILE}'       => $this->profile,
+      '{DOCUMENT_ROOT}' => getenv('DOCUMENT_ROOT')
     ]) : $value;
   }
   

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -73,7 +73,7 @@ class Runner extends \lang\Object {
    * Entry point method. Receives the following arguments from web.php:
    * 
    * 0. The web root - a directory
-   * 1. The application source - either a directory or ":" + f.q.c.Name
+   * 1. The application source - either a directory or a layout or scriptlet class name
    * 2. The server profile - any name, really, defaulting to "dev"
    * 3. The script URL - the resolved path, including leading "/"
    *
@@ -82,7 +82,9 @@ class Runner extends \lang\Object {
    */
   public static function main(array $args) {
     $self= new self($args[0], $args[2]);
-    $self->layout((new Source($args[1], new Config([], [$self, 'expand'])))->layout())->run($args[3]);
+    $config= explode(PATH_SEPARATOR, $args[1]);
+    $source= array_shift($config);
+    $self->layout((new Source($source, new Config($config, [$self, 'expand'])))->layout())->run($args[3]);
   }
   
   /**

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -72,10 +72,10 @@ class Runner extends \lang\Object {
   /**
    * Entry point method. Receives the following arguments from web.php:
    * 
-   * 1. The web root - a directory
-   * 2. The application source - either a directory or ":" + f.q.c.Name
-   * 3. The server profile - any name, really, defaulting to "dev"
-   * 4. The script URL - the resolved path, including leading "/"
+   * 0. The web root - a directory
+   * 1. The application source - either a directory or ":" + f.q.c.Name
+   * 2. The server profile - any name, really, defaulting to "dev"
+   * 3. The script URL - the resolved path, including leading "/"
    *
    * @param  string[] $args
    * @return void

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -154,13 +154,8 @@ class Runner extends \lang\Object {
     // Initializer logger, properties and connections to property base, 
     // defaulting to the same directory the web.ini resides in
     $pm= PropertyManager::getInstance();
-    foreach ($application->config() as $element) {
-      $expanded= $this->expand($element);
-      if (0 == strncmp('res://', $expanded, 6)) {
-        $pm->appendSource(new ResourcePropertySource(substr($expanded, 6)));
-      } else {
-        $pm->appendSource(new FilesystemPropertySource($expanded));
-      }
+    foreach ($application->config()->sources() as $source) {
+      $pm->appendSource($source);
     }
     
     $l= Logger::getInstance();

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -82,7 +82,7 @@ class Runner extends \lang\Object {
    */
   public static function main(array $args) {
     $self= new self($args[0], $args[2]);
-    $config= explode(PATH_SEPARATOR, $args[1]);
+    $config= explode(PATH_SEPARATOR, ltrim($args[1], PATH_SEPARATOR));
     $source= array_shift($config);
     $self->layout((new Source($source, new Config($config, [$self, 'expand'])))->layout())->run($args[3]);
   }

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -92,7 +92,7 @@ class Runner extends \lang\Object {
       if (0 === strlen($dir)) {
         // Skip
       } else if ('~' === $dir{0}) {
-        $config->append($args[0].substr($dir, 1));
+        $config->append($self->webroot.substr($dir, 1));
       } else {
         $config->append($dir);
       }

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -82,7 +82,7 @@ class Runner extends \lang\Object {
    */
   public static function main(array $args) {
     $self= new self($args[0], $args[2]);
-    $config= explode(PATH_SEPARATOR, ltrim($args[1], PATH_SEPARATOR));
+    $config= explode(PATH_SEPARATOR, ltrim($args[1], ':'));
     $source= array_shift($config);
     $self->layout((new Source($source, new Config($config, [$self, 'expand'])))->layout())->run($args[3]);
   }

--- a/src/main/php/xp/scriptlet/ScriptletHandler.class.php
+++ b/src/main/php/xp/scriptlet/ScriptletHandler.class.php
@@ -3,6 +3,7 @@
 use peer\URL;
 use peer\Socket;
 use scriptlet\ScriptletException;
+use lang\XPClass;
 
 /**
  * Scriptlet handler
@@ -13,16 +14,15 @@ class ScriptletHandler extends AbstractUrlHandler {
   /**
    * Constructor
    *
-   * @param   string name
+   * @param   lang.XPClass $scriptlet
    * @param   string[] args
    * @param   [:string] env
    */
-  public function __construct($name, $args, $env= [], $filters= []) {
-    $class= \lang\XPClass::forName($name);
-    if ($class->hasConstructor()) {
-      $this->scriptlet= $class->getConstructor()->newInstance((array)$args);
+  public function __construct(XPClass $scriptlet, $args, $env= [], $filters= []) {
+    if ($scriptlet->hasConstructor()) {
+      $this->scriptlet= $scriptlet->getConstructor()->newInstance((array)$args);
     } else {
-      $this->scriptlet= $class->newInstance();
+      $this->scriptlet= $scriptlet->newInstance();
     }
 
     foreach ($filters as $filter) {

--- a/src/main/php/xp/scriptlet/Server.class.php
+++ b/src/main/php/xp/scriptlet/Server.class.php
@@ -9,7 +9,7 @@ class Server {
    * Entry point method. Receives the following arguments from xpws:
    *
    * 0. The web root - defaults to $CWD
-   * 1. The application source - either a directory or ":" + f.q.c.Name
+   * 1. The application source - either a directory or a layout or scriptlet class name
    * 2. The server profile - default to "dev"
    * 3. The server address - default to "localhost:8080"
    * 4. The mode - default to "serve" (can include further arguments to the server constructor separated by commas)
@@ -18,13 +18,24 @@ class Server {
    * @return  int
    */
   public static function main(array $args) {
-    WebRunner::main([
+    $args= [
       '-r', isset($args[0]) ? realpath($args[0]) : getcwd(),
       '-p', isset($args[2]) ? $args[2] : 'dev',
       '-a', isset($args[3]) ? $args[3] : 'localhost:8080',
-      '-m', isset($args[4]) ? $args[4] : 'serve',
-      isset($args[1]) ? $args[1] : 'etc'
-    ]);
+      '-m', isset($args[4]) ? $args[4] : 'serve'
+    ];
+
+    if (isset($args[1])) {
+      $sources= explode(PATH_SEPARATOR, ltrim($args[1], ':'));
+      $source= array_shift($sources);
+      foreach ($sources as $dir) {
+        $args[]= '-c';
+        $args[]= $dir;
+      }
+      $args[]= $source;
+    }
+
+    WebRunner::main($args);
     return 0;
   }
 }

--- a/src/main/php/xp/scriptlet/Server.class.php
+++ b/src/main/php/xp/scriptlet/Server.class.php
@@ -1,118 +1,30 @@
 <?php namespace xp\scriptlet;
 
-use util\cmd\Console;
-use util\PropertyManager;
-use util\ResourcePropertySource;
-use util\FilesystemPropertySource;
-use util\log\Logger;
-use util\log\context\EnvironmentAware;
-use rdbms\ConnectionManager;
-use lang\XPClass;
-
 /**
  * Web server
  */
-class Server extends \lang\Object {
-  protected static $modes= [
-    'serve'   => 'peer.server.Server',
-    'prefork' => 'peer.server.PreforkingServer',
-    'fork'    => 'peer.server.ForkingServer',
-    'event'   => 'peer.server.EventServer'
-  ];
-
-  static function __static() {
-    \lang\XPClass::forName('lang.ResourceProvider');
-  }
+class Server {
 
   /**
    * Entry point method. Receives the following arguments from xpws:
    *
-   * 1. The web root - defaults to $CWD
-   * 2. The application source - either a directory or ":" + f.q.c.Name
-   * 3. The server profile - default to "dev"
-   * 4. The server address - default to "localhost:8080"
-   * 5. The mode - default to "serve" (can include further arguments to the server constructor separated by commas)
+   * 0. The web root - defaults to $CWD
+   * 1. The application source - either a directory or ":" + f.q.c.Name
+   * 2. The server profile - default to "dev"
+   * 3. The server address - default to "localhost:8080"
+   * 4. The mode - default to "serve" (can include further arguments to the server constructor separated by commas)
    *
    * @param   string[] args
    * @return  int
    */
   public static function main(array $args) {
-    $webroot= isset($args[0]) ? realpath($args[0]) : getcwd();
-    $source= isset($args[1]) ? $args[1] : 'etc';
-    $profile= isset($args[2]) ? $args[2] : 'dev';
-    $address= isset($args[3]) ? $args[3] : 'localhost:8080';
-
-    if (isset($args[4])) {
-      $arguments= explode(',', $args[4]);
-      $mode= array_shift($arguments);
-    } else {
-      $arguments= [];
-      $mode= 'serve';
-    }
-
-    if (!($class= @self::$modes[$mode])) {
-      Console::writeLine('*** Unkown server mode "', $mode, '", supported: ', self::$modes);
-      return 2;
-    }
-
-    $expand= function($in) use($webroot, $profile) {
-      return is_string($in) ? strtr($in, [
-        '{WEBROOT}'       => $webroot,
-        '{PROFILE}'       => $profile,
-        '{DOCUMENT_ROOT}' => getenv('DOCUMENT_ROOT')
-      ]) : $in;
-    };
-
-    Console::writeLine('---> Startup ', $class, '(', $address, ')');
-    sscanf($address, '%[^:]:%d', $host, $port);
-    $server= XPClass::forName($class)->getConstructor()->newInstance(array_merge([$host, $port], $arguments));
-    Console::writeLine('---> ', $server);
-    // $server->setTrace((new \util\log\LogCategory())->withAppender(new \util\log\ConsoleAppender()));
-
-    with ($pm= PropertyManager::getInstance(), $protocol= $server->setProtocol(new HttpProtocol())); {
-      $layout= (new Source($source))->layout();
-
-      $resources= $layout->staticResources($profile);
-      if (null === $resources) {
-        $protocol->setUrlHandler('default', '#^/#', new FileHandler(
-          $expand('{DOCUMENT_ROOT}'),
-          $notFound= function() { return false; }
-        ));
-      } else {
-        foreach ($resources as $pattern => $location) {
-          $protocol->setUrlHandler('default', '#'.strtr($pattern, ['#' => '\\#']).'#', new FileHandler($expand($location)));
-        }
-      }
-      foreach ($layout->mappedApplications($profile) as $url => $application) {
-        $protocol->setUrlHandler('default', '/' == $url ? '##' : '#^('.preg_quote($url, '#').')($|/.+)#', new ScriptletHandler(
-          $application->scriptlet(),
-          array_map($expand, $application->arguments()),
-          array_map($expand, array_merge($application->environment(), [
-            'DOCUMENT_ROOT' => getenv('DOCUMENT_ROOT')
-          ])),
-          $application->filters()
-        ));
-        foreach ($application->config() as $element) {
-          $expanded= $expand($element);
-          if (0 == strncmp('res://', $expanded, 6)) {
-            $pm->appendSource(new ResourcePropertySource(substr($expanded, 6)));
-          } else {
-            $pm->appendSource(new FilesystemPropertySource($expanded));
-          }
-        }
-      }
-
-      $l= Logger::getInstance();
-      $pm->hasProperties('log') && $l->configure($pm->getProperties('log'));
-      $cm= ConnectionManager::getInstance();
-      $pm->hasProperties('database') && $cm->configure($pm->getProperties('database'));
-      Console::writeLine($protocol);
-    }
-    $server->init();
-
-    Console::writeLine('===> Server started');
-    $server->service();
-    $server->shutdown();
+    WebRunner::main([
+      '-r', isset($args[0]) ? realpath($args[0]) : getcwd(),
+      '-p', isset($args[2]) ? $args[2] : 'dev',
+      '-a', isset($args[3]) ? $args[3] : 'localhost:8080',
+      '-m', isset($args[4]) ? $args[4] : 'serve',
+      isset($args[1]) ? $args[1] : 'etc'
+    ]);
     return 0;
   }
 }

--- a/src/main/php/xp/scriptlet/Server.class.php
+++ b/src/main/php/xp/scriptlet/Server.class.php
@@ -18,7 +18,7 @@ class Server {
    * @return  int
    */
   public static function main(array $args) {
-    $args= [
+    $pass= [
       '-r', isset($args[0]) ? realpath($args[0]) : getcwd(),
       '-p', isset($args[2]) ? $args[2] : 'dev',
       '-a', isset($args[3]) ? $args[3] : 'localhost:8080',
@@ -29,13 +29,13 @@ class Server {
       $sources= explode(PATH_SEPARATOR, ltrim($args[1], ':'));
       $source= array_shift($sources);
       foreach ($sources as $dir) {
-        $args[]= '-c';
-        $args[]= $dir;
+        $pass[]= '-c';
+        $pass[]= $dir;
       }
-      $args[]= $source;
+      $pass[]= $source;
     }
 
-    WebRunner::main($args);
+    WebRunner::main($pass);
     return 0;
   }
 }

--- a/src/main/php/xp/scriptlet/SingleScriptlet.class.php
+++ b/src/main/php/xp/scriptlet/SingleScriptlet.class.php
@@ -6,15 +6,17 @@
  * @see   xp://xp.scriptlet.WebApplication
  */
 class SingleScriptlet extends \lang\Object implements WebLayout {
-  private $scriptlet;
+  private $scriptlet, $config;
 
   /**
    * Creates a new instance
    *
-   * @param  string $scripltet
+   * @param  string $scriptlet
+   * @param  xp.scriptlet.Config $config
    */
-  public function __construct($scriptlet) {
+  public function __construct($scriptlet, Config $config= null) {
     $this->scriptlet= $scriptlet;
+    $this->config= $config;
   }
 
   /**
@@ -25,7 +27,7 @@ class SingleScriptlet extends \lang\Object implements WebLayout {
    * @throws  lang.IllegalStateException if the web is misconfigured
    */
   public function mappedApplications($profile= null) {
-    return ['/' => (new WebApplication('default'))->withScriptlet($this->scriptlet)];
+    return ['/' => (new WebApplication('default'))->withScriptlet($this->scriptlet)->withConfig($this->config)];
   }
 
   /**
@@ -40,6 +42,6 @@ class SingleScriptlet extends \lang\Object implements WebLayout {
 
   /** @return string */
   public function toString() {
-    return nameof($this).'('.$this->scriptlet.')';
+    return nameof($this).'('.$this->scriptlet.($this->config ? ' << '.$this->config->toString() : '').')';
   }
 }

--- a/src/main/php/xp/scriptlet/Source.class.php
+++ b/src/main/php/xp/scriptlet/Source.class.php
@@ -2,6 +2,8 @@
 
 use io\Path;
 use util\Properties;
+use util\RegisteredPropertySource;
+use util\FileSystemPropertySource;
 use lang\XPClass;
 use lang\IllegalArgumentException;
 use lang\ClassLoadingException;
@@ -25,9 +27,9 @@ class Source extends \lang\Object {
     if ('-' === $source) {
       $this->layout= new ServeDocumentRootStatically();
     } else if (is_file($source)) {
-      $this->layout= new WebConfiguration(new Properties($source));
+      $this->layout= new WebConfiguration(new Properties($source), $config);
     } else if (is_dir($source)) {
-      $this->layout= new WebConfiguration(new Properties(new Path($source, WebConfiguration::INI)));
+      $this->layout= new WebConfiguration(new Properties(new Path($source, WebConfiguration::INI)), $config);
     } else {
       $name= ltrim($source, ':');
       try {

--- a/src/main/php/xp/scriptlet/Source.class.php
+++ b/src/main/php/xp/scriptlet/Source.class.php
@@ -4,7 +4,7 @@ use io\Path;
 use util\Properties;
 use lang\XPClass;
 use lang\IllegalArgumentException;
-use lang\CLassLoadingException;
+use lang\ClassLoadingException;
 
 /**
  * Represent the source argument
@@ -18,28 +18,35 @@ class Source extends \lang\Object {
    * Creates a new instance
    *
    * @param  string $source
+   * @param  xp.scriptlet.Config $config
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($source) {
+  public function __construct($source, Config $config= null) {
     if ('-' === $source) {
       $this->layout= new ServeDocumentRootStatically();
-    } else if (':' === $source{0}) {
-      $name= substr($source, 1);
+    } else if (is_file($source)) {
+      $this->layout= new WebConfiguration(new Properties($source));
+    } else if (is_dir($source)) {
+      $this->layout= new WebConfiguration(new Properties(new Path($source, WebConfiguration::INI)));
+    } else {
+      $name= ltrim($source, ':');
       try {
         $class= XPClass::forName($name);
-      } catch (CLassLoadingException $e) {
+      } catch (ClassLoadingException $e) {
         throw new IllegalArgumentException('Cannot load '.$name, $e);
       }
 
       if ($class->isSubclassOf('scriptlet.HttpScriptlet')) {
-        $this->layout= new SingleScriptlet($class->getName());
+        $this->layout= new SingleScriptlet($class->getName(), $config);
       } else if ($class->isSubclassOf('xp.scriptlet.WebLayout')) {
-        $this->layout= $class->newInstance();
+        if ($class->hasMethod('newInstance')) {
+          $this->layout= $class->getMethod('newInstance')->invoke(null, [$config]);
+        } else {
+          $this->layout= $class->newInstance();
+        }
       } else {
-        throw new IllegalArgumentException('Expecting either a scriptlet, a weblayout or a config file');
+        throw new IllegalArgumentException('Expecting either a scriptlet or a weblayout, '.$class->getName().' given');
       }
-    } else {
-      $this->layout= new WebConfiguration(new Properties((new Path($source, 'web.ini'))->toString()));
     }
   }
 

--- a/src/main/php/xp/scriptlet/Source.class.php
+++ b/src/main/php/xp/scriptlet/Source.class.php
@@ -38,14 +38,14 @@ class Source extends \lang\Object {
         throw new IllegalArgumentException('Cannot load '.$name, $e);
       }
 
-      if ($class->isSubclassOf('scriptlet.HttpScriptlet')) {
-        $this->layout= new SingleScriptlet($class->getName(), $config);
-      } else if ($class->isSubclassOf('xp.scriptlet.WebLayout')) {
+      if ($class->isSubclassOf('xp.scriptlet.WebLayout')) {
         if ($class->hasMethod('newInstance')) {
           $this->layout= $class->getMethod('newInstance')->invoke(null, [$config]);
         } else {
           $this->layout= $class->newInstance();
         }
+      } else if ($class->isSubclassOf('scriptlet.HttpScriptlet')) {
+        $this->layout= new SingleScriptlet($class->getName(), $config);
       } else {
         throw new IllegalArgumentException('Expecting either a scriptlet or a weblayout, '.$class->getName().' given');
       }

--- a/src/main/php/xp/scriptlet/Source.class.php
+++ b/src/main/php/xp/scriptlet/Source.class.php
@@ -39,8 +39,8 @@ class Source extends \lang\Object {
       }
 
       if ($class->isSubclassOf('xp.scriptlet.WebLayout')) {
-        if ($class->hasMethod('newInstance')) {
-          $this->layout= $class->getMethod('newInstance')->invoke(null, [$config]);
+        if ($class->hasConstructor()) {
+          $this->layout= $class->getConstructor()->newInstance([$config]);
         } else {
           $this->layout= $class->newInstance();
         }

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -9,7 +9,7 @@ use scriptlet\Filter;
  * @see      xp://xp.scriptlet.Runner
  */
 class WebApplication extends \lang\Object {
-  protected $name = '';
+  protected $name;
   protected $config;
   protected $scriptlet = '';
   protected $arguments = [];
@@ -20,7 +20,7 @@ class WebApplication extends \lang\Object {
   /**
    * Creates a new web application named by the given name
    *
-   * @param   string name
+   * @param   string $name
    */
   public function __construct($name) {
     $this->name= $name;
@@ -29,7 +29,7 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's name
    *
-   * @param   string name
+   * @param   string $name
    * @return  self this
    */
   public function withName($name) {
@@ -49,7 +49,7 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's config
    *
-   * @param   xp.scriptlet.Config|string[]|string config
+   * @param   xp.scriptlet.Config|string|string[] $config
    * @return  self this
    */
   public function withConfig($config) {
@@ -75,7 +75,7 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's debug flags
    *
-   * @param   int debug
+   * @param   int $debug
    * @return  self this
    */
   public function withDebug($debug) {
@@ -95,7 +95,7 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's scriptlet class name
    *
-   * @param   string scriptlet
+   * @param   string $scriptlet
    * @return  self this
    */
   public function withScriptlet($scriptlet) {
@@ -115,7 +115,7 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's arguments
    *
-   * @param   string[] arguments
+   * @param   string[] $arguments
    * @return  self this
    */
   public function withArguments($arguments) {
@@ -135,7 +135,7 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's filter class name
    *
-   * @param   scriptlet.Filter|string filter Either a filter instance or a filter class name
+   * @param   scriptlet.Filter|string $filter Either a filter instance or a filter class name
    * @return  xp.filter.WebApplication this
    */
   public function withFilter($filter) {
@@ -159,7 +159,7 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's environment
    *
-   * @param   [:string] environment
+   * @param   [:string] $environment
    * @return  self this
    */
   public function withEnvironment($environment) {
@@ -203,7 +203,7 @@ class WebApplication extends \lang\Object {
   /**
    * Returns whether another object is equal to this
    *
-   * @param   lang.Generic cmp
+   * @param   lang.Generic $cmp
    * @return  bool
    */
   public function equals($cmp) {

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -10,7 +10,7 @@ use scriptlet\Filter;
  */
 class WebApplication extends \lang\Object {
   protected $name = '';
-  protected $config = [];
+  protected $config;
   protected $scriptlet = '';
   protected $arguments = [];
   protected $filters = [];
@@ -49,14 +49,16 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's config
    *
-   * @param   string[]|string config
+   * @param   xp.scriptlet.Config|string[]|string config
    * @return  self this
    */
   public function withConfig($config) {
-    if (is_array($config)) {
+    if ($config instanceof Config) {
       $this->config= $config;
+    } else if (is_array($config)) {
+      $this->config= new Config($config);
     } else {
-      $this->config= [$config];
+      $this->config= new Config([$config]);
     }
     return $this;
   }
@@ -64,10 +66,10 @@ class WebApplication extends \lang\Object {
   /**
    * Returns this application's config
    *
-   * @return  string[]
+   * @return  xp.scriptlet.Config
    */
   public function config() {
-    return $this->config;
+    return $this->config ?: new Config();
   }
 
   /**
@@ -190,7 +192,7 @@ class WebApplication extends \lang\Object {
       "}",
       nameof($this),
       $this->name,
-      $this->config,
+      strtr($this->config->toString(), ["\n" => "\n  "]),
       $this->scriptlet,
       implode(' | ', WebDebug::namesOf($this->debug)),
       implode(', ', $this->arguments),
@@ -208,11 +210,11 @@ class WebApplication extends \lang\Object {
     return (
       $cmp instanceof self && 
       $this->name === $cmp->name && 
-      $this->config === $cmp->config && 
       $this->scriptlet === $cmp->scriptlet && 
       $this->debug === $cmp->debug && 
       $this->arguments === $cmp->arguments &&
-      $this->environment === $cmp->environment
+      $this->environment === $cmp->environment &&
+      0 === $this->config->compareTo($cmp->config)
     );
   }
 }

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -1,6 +1,7 @@
 <?php namespace xp\scriptlet;
 
 use scriptlet\Filter;
+use lang\XPClass;
 
 /**
  * Represents a web application
@@ -10,8 +11,8 @@ use scriptlet\Filter;
  */
 class WebApplication extends \lang\Object {
   protected $name;
-  protected $config;
-  protected $scriptlet = '';
+  protected $config = null;
+  protected $scriptlet = null;
   protected $arguments = [];
   protected $filters = [];
   protected $environment = [];
@@ -95,18 +96,24 @@ class WebApplication extends \lang\Object {
   /**
    * Sets this application's scriptlet class name
    *
-   * @param   string $scriptlet
+   * @param   string|lang.XPClass $scriptlet
    * @return  self this
    */
   public function withScriptlet($scriptlet) {
-    $this->scriptlet= $scriptlet;
+    if (null === $scriptlet) {
+      $this->scriptlet= null;
+    } else if ($scriptlet instanceof XPClass) {
+      $this->scriptlet= $scriptlet;
+    } else {
+      $this->scriptlet= XPClass::forName($scriptlet);
+    }
     return $this;
   }
   
   /**
    * Returns this application's scriptlet class
    *
-   * @return  string
+   * @return  lang.XPClass
    */
   public function scriptlet() {
     return $this->scriptlet;
@@ -192,8 +199,8 @@ class WebApplication extends \lang\Object {
       "}",
       nameof($this),
       $this->name,
-      strtr($this->config->toString(), ["\n" => "\n  "]),
-      $this->scriptlet,
+      $this->config ? strtr($this->config->toString(), ["\n" => "\n  "]) : '(none)',
+      $this->scriptlet ? $this->scriptlet->getName() : '(none)',
       implode(' | ', WebDebug::namesOf($this->debug)),
       implode(', ', $this->arguments),
       \xp::stringOf($this->environment, '  ')
@@ -210,10 +217,10 @@ class WebApplication extends \lang\Object {
     return (
       $cmp instanceof self && 
       $this->name === $cmp->name && 
-      $this->scriptlet === $cmp->scriptlet && 
       $this->debug === $cmp->debug && 
       $this->arguments === $cmp->arguments &&
       $this->environment === $cmp->environment &&
+      $this->scriptlet === null ? null === $cmp->scriptlet : $this->scriptlet->equals($cmp->scriptlet) &&
       0 === $this->config->compareTo($cmp->config)
     );
   }

--- a/src/main/php/xp/scriptlet/WebConfiguration.class.php
+++ b/src/main/php/xp/scriptlet/WebConfiguration.class.php
@@ -92,7 +92,7 @@ class WebConfiguration extends \lang\Object implements WebLayout {
     }
 
     $app= new WebApplication($application);
-    $app->withScriptlet($this->readString($profile, $section, 'class', ''));
+    $app->withScriptlet($this->readString($profile, $section, 'class', null));
 
     // Configure app
     $config= $this->config ? clone $this->config : new Config();

--- a/src/main/php/xp/scriptlet/WebConfiguration.class.php
+++ b/src/main/php/xp/scriptlet/WebConfiguration.class.php
@@ -12,15 +12,17 @@ use lang\IllegalStateException;
 class WebConfiguration extends \lang\Object implements WebLayout {
   const INI = 'web.ini';
 
-  protected $prop= null;
+  private $prop, $config;
   
   /**
    * Creates a new web configuration instance
    *
-   * @param   util.Properties prop
+   * @param  util.Properties $prop
+   * @param  xp.scriptlet.Config $config
    */
-  public function __construct(Properties $prop) {
+  public function __construct(Properties $prop, Config $config= null) {
     $this->prop= $prop;
+    $this->config= $config;
   }
 
   /**
@@ -91,8 +93,13 @@ class WebConfiguration extends \lang\Object implements WebLayout {
 
     $app= new WebApplication($application);
     $app->withScriptlet($this->readString($profile, $section, 'class', ''));
-    
-    $app->withConfig($this->readArray($profile, $section, 'prop-base', '{WEBROOT}/etc'));
+
+    // Configure app
+    $config= $this->config ? clone $this->config : new Config();
+    foreach ($this->readArray($profile, $section, 'prop-base', ['{WEBROOT}/etc']) as $prop) {
+      $config->append($prop);
+    }
+    $app->withConfig($config);
 
     // Determine debug level
     $flags= WebDebug::NONE;

--- a/src/main/php/xp/scriptlet/WebRunner.class.php
+++ b/src/main/php/xp/scriptlet/WebRunner.class.php
@@ -176,13 +176,8 @@ class WebRunner {
           array_map($expand, array_merge($application->environment(), ['DOCUMENT_ROOT' => $docroot])),
           $application->filters()
         ));
-        foreach ($application->config() as $element) {
-          $expanded= $expand($element);
-          if (0 == strncmp('res://', $expanded, 6)) {
-            $pm->appendSource(new ResourcePropertySource(substr($expanded, 6)));
-          } else {
-            $pm->appendSource(new FilesystemPropertySource($expanded));
-          }
+        foreach ($application->config()->sources() as $source) {
+          $pm->appendSource($source);
         }
       }
 

--- a/src/main/php/xp/scriptlet/WebRunner.class.php
+++ b/src/main/php/xp/scriptlet/WebRunner.class.php
@@ -54,7 +54,8 @@ new import('lang.ResourceProvider');
  *   $ xp web -m event
  *   ```
  * The address the server listens to can be supplied via *-a {host}:{port}*.
- * The profile can be changed via *-p {profile}* (and can be anything!).
+ * The profile can be changed via *-p {profile}* (and can be anything!). One
+ * or more configuration sources may be passed via *-c {file.ini|dir}*.
  */
 class WebRunner {
   private static $modes= [

--- a/src/main/php/xp/scriptlet/WebRunner.class.php
+++ b/src/main/php/xp/scriptlet/WebRunner.class.php
@@ -6,9 +6,6 @@ use lang\ClassLoader;
 use lang\IllegalArgumentException;
 use util\cmd\Console;
 use util\PropertyManager;
-use util\Properties;
-use util\ResourcePropertySource;
-use util\FilesystemPropertySource;
 use util\log\Logger;
 use util\log\context\EnvironmentAware;
 use rdbms\ConnectionManager;
@@ -98,7 +95,6 @@ class WebRunner {
    */
   public static function main(array $args) {
     $webroot= new Path(getcwd());
-
     $docroot= new Path($webroot, 'static');
     $address= 'localhost:8080';
     $profile= 'dev';

--- a/src/main/php/xp/scriptlet/WebRunner.class.php
+++ b/src/main/php/xp/scriptlet/WebRunner.class.php
@@ -9,7 +9,7 @@ use util\PropertyManager;
 use util\log\Logger;
 use util\log\context\EnvironmentAware;
 use rdbms\ConnectionManager;
-use peer\server\Server;
+use peer\server\Server as DefaultServer;
 use peer\server\PreforkingServer;
 use peer\server\ForkingServer;
 use peer\server\EventServer;
@@ -56,7 +56,7 @@ new import('lang.ResourceProvider');
  */
 class WebRunner {
   private static $modes= [
-    'serve'   => Server::class,
+    'serve'   => DefaultServer::class,
     'prefork' => PreforkingServer::class,
     'fork'    => ForkingServer::class,
     'event'   => EventServer::class

--- a/src/main/php/xp/scriptlet/WebRunner.class.php
+++ b/src/main/php/xp/scriptlet/WebRunner.class.php
@@ -106,7 +106,6 @@ class WebRunner {
     $arguments= [];
 
     $config= new Config();
-    $cl= ClassLoader::getDefault();
     for ($i= 0; $i < sizeof($args); $i++) {
        if ('-r' === $args[$i]) {
         $docroot= $args[++$i];
@@ -119,25 +118,9 @@ class WebRunner {
       } else if ('-m' === $args[$i]) {
         $arguments= explode(',', $args[++$i]);
         $mode= array_shift($arguments);
-      } else if ('-' === $args[$i]) {
-        $layout= new ServeDocumentRootStatically();
-      } else if (is_file($args[$i])) {
-        $layout= new WebConfiguration(new Properties($args[$i]));
-      } else if (is_dir($args[$i])) {
-        $layout= new WebConfiguration(new Properties(new Path($args[$i], WebConfiguration::INI)));
-      } else if ($cl->providesClass($args[$i])) {
-        $class= $cl->loadClass($args[$i]);
-        if ($class->isSubclassOf(HttpScriptlet::class)) {
-          $layout= new SingleScriptlet($class->getName(), $config);
-        } else if ($class->isSubclassOf(WebLayout::class)) {
-          if ($class->hasMethod('newInstance')) {
-            $layout= $class->getMethod('newInstance')->invoke(null, [$config]);
-          } else {
-            $layout= $class->newInstance();
-          }
-        } else {
-          throw new IllegalArgumentException('Expecting either a scriptlet or a weblayout, '.$class->getName().' given');
-        }
+      } else {
+        $layout= (new Source($args[$i], $config))->layout();
+        break;
       }
     }
 

--- a/src/test/php/scriptlet/unittest/ConfigTest.class.php
+++ b/src/test/php/scriptlet/unittest/ConfigTest.class.php
@@ -56,6 +56,14 @@ class ConfigTest extends \unittest\TestCase {
     $this->assertEquals([new ResourcePropertySource('live')], $config->sources());
   }
 
+  #[@test]
+  public function append_source() {
+    $config= new Config();
+    $source= new FilesystemPropertySource('.');
+    $config->append($source);
+    $this->assertEquals([$source], $config->sources());
+  }
+
   #[@test, @expect(ElementNotFoundException::class)]
   public function properties_raises_exception_when_nothing_found() {
     (new Config())->properties('test');
@@ -66,5 +74,12 @@ class ConfigTest extends \unittest\TestCase {
     $config= new Config();
     $config->append('user');
     $this->assertEquals('value', $config->properties('debug')->readString('section', 'key'));
+  }
+
+  #[@test]
+  public function expand() {
+    $config= new Config([], function($in) { return 'res://'.strtolower(substr($in, 1, -1)); });
+    $config->append('{USER}');
+    $this->assertEquals([new ResourcePropertySource('user')], $config->sources());
   }
 }

--- a/src/test/php/scriptlet/unittest/ConfigTest.class.php
+++ b/src/test/php/scriptlet/unittest/ConfigTest.class.php
@@ -1,0 +1,70 @@
+<?php namespace scriptlet\unittest;
+ 
+use xp\scriptlet\Config;
+use util\FilesystemPropertySource;
+use util\ResourcePropertySource;
+use util\PropertyAccess;
+use lang\ElementNotFoundException;
+
+class ConfigTest extends \unittest\TestCase {
+  
+  #[@test]
+  public function can_create() {
+    new Config();
+  }
+
+  #[@test]
+  public function initially_empty() {
+    $this->assertTrue((new Config())->isEmpty());
+  }
+
+  #[@test]
+  public function not_empty_if_created_with_source() {
+    $this->assertFalse((new Config(['.']))->isEmpty());
+  }
+
+  #[@test]
+  public function not_empty_if_created_with_sources() {
+    $this->assertFalse((new Config(['.', 'user']))->isEmpty());
+  }
+
+  #[@test]
+  public function no_longer_empty_after_appending_source() {
+    $config= new Config();
+    $config->append('.');
+    $this->assertFalse($config->isEmpty());
+  }
+
+  #[@test]
+  public function append_dir() {
+    $config= new Config();
+    $config->append('.');
+    $this->assertEquals([new FilesystemPropertySource('.')], $config->sources());
+  }
+
+  #[@test]
+  public function append_resource() {
+    $config= new Config();
+    $config->append('live');
+    $this->assertEquals([new ResourcePropertySource('live')], $config->sources());
+  }
+
+  #[@test]
+  public function append_resource_with_explicit_res_prefix() {
+    $config= new Config();
+    $config->append('res://live');
+    $this->assertEquals([new ResourcePropertySource('live')], $config->sources());
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function properties_raises_exception_when_nothing_found() {
+    (new Config())->properties('test');
+  }
+
+  #[@test]
+  public function properties() {
+    $config= new Config();
+    $config->append('user');
+    $this->assertEquals('value', $config->properties('debug')->readString('section', 'key'));
+  }
+}

--- a/src/test/php/scriptlet/unittest/HttpSessionTest.class.php
+++ b/src/test/php/scriptlet/unittest/HttpSessionTest.class.php
@@ -6,16 +6,11 @@ use unittest\TestCase;
 use util\Date;
 use io\Folder;
 
-/**
- * TestCase for scriptlet.HttpSession class.
- *
- * @purpose   TestCase
- */
 class HttpSessionTest extends TestCase {
-  protected $session= null;
+  private $session= null;
 
-  /** @return  scriptlet.HttpSession */
-  protected function _session() { return new HttpSession(); }
+  /** @return scriptlet.HttpSession */
+  private function _session() { return new HttpSession(); }
 
   /**
    * Setup testcase environment for next testcase

--- a/src/test/php/scriptlet/unittest/RunnerTest.class.php
+++ b/src/test/php/scriptlet/unittest/RunnerTest.class.php
@@ -573,10 +573,28 @@ class RunnerTest extends TestCase {
   }
 
   #[@test]
-  public function main_with_layout_class_and_config() {
+  public function main_with_layout_class_and_config_resources() {
     $this->assertEquals(
       '<h1>Welcome, we are open & xp.scriptlet.Config[util.ResourcePropertySource<res://config>]</h1>',
       $this->run('.', self::$layout->getName().PATH_SEPARATOR.'config', 'dev', '/')
+    );
+  }
+
+  #[@test]
+  public function main_with_layout_class_and_config_dir() {
+    $temp= realpath('.');
+    $this->assertEquals(
+      '<h1>Welcome, we are open & xp.scriptlet.Config[util.FilesystemPropertySource<'.$temp.'>]</h1>',
+      $this->run('.', self::$layout->getName().PATH_SEPARATOR.$temp, 'dev', '/')
+    );
+  }
+
+  #[@test]
+  public function main_with_layout_class_and_config_tilde() {
+    $temp= realpath('.');
+    $this->assertEquals(
+      '<h1>Welcome, we are open & xp.scriptlet.Config[util.FilesystemPropertySource<'.$temp.'>]</h1>',
+      $this->run('.', self::$layout->getName().PATH_SEPARATOR.'~', 'dev', '/')
     );
   }
 

--- a/src/test/php/scriptlet/unittest/RunnerTest.class.php
+++ b/src/test/php/scriptlet/unittest/RunnerTest.class.php
@@ -581,6 +581,14 @@ class RunnerTest extends TestCase {
   }
 
   #[@test]
+  public function main_with_layout_class_bc_colon_prefix() {
+    $this->assertEquals(
+      '<h1>Welcome, we are open & xp.scriptlet.Config[]</h1>',
+      $this->run('.', ':'.self::$layout->getName(), 'dev', '/')
+    );
+  }
+
+  #[@test]
   public function properties() {
     $r= new Runner('/var/www', 'dev');
     $r->mapApplication('/debug', (new \xp\scriptlet\WebApplication('debug'))

--- a/src/test/php/scriptlet/unittest/RunnerTest.class.php
+++ b/src/test/php/scriptlet/unittest/RunnerTest.class.php
@@ -523,7 +523,7 @@ class RunnerTest extends TestCase {
 
     $this->assertEquals('412', $error[1], 'error message');
     $this->assertEquals(
-      'Exception lang.ClassNotFoundException (Class "" could not be found) {', 
+      'Exception lang.IllegalStateException (No scriptlet in xp.scriptlet.WebApplication(incomplete)@{', 
       $compound[1],
       'exception compound message'
     );

--- a/src/test/php/scriptlet/unittest/RunnerTest.class.php
+++ b/src/test/php/scriptlet/unittest/RunnerTest.class.php
@@ -93,10 +93,8 @@ class RunnerTest extends TestCase {
     self::$layout= \lang\ClassLoader::defineClass('Layout', 'lang.Object', ['xp.scriptlet.WebLayout'], '{
       private $config;
 
-      public static function newInstance($config) {
-        $self= new self();
-        $self->config= $config;
-        return $self;
+      public function __construct($config) {
+        $this->config= $config;
       }
 
       public function mappedApplications($profile= null) {

--- a/src/test/php/scriptlet/unittest/SourceTest.class.php
+++ b/src/test/php/scriptlet/unittest/SourceTest.class.php
@@ -3,9 +3,10 @@
 use lang\IllegalArgumentException;
 use xp\scriptlet\Source;
 use lang\ClassLoader;
+use lang\System;
 
 class SourceTest extends \unittest\TestCase {
-  private static $scriptlet, $layout;
+  private static $scriptlet, $layout, $dir, $file;
 
   #[@beforeClass]
   public static function defineScriptlet() {
@@ -20,6 +21,26 @@ class SourceTest extends \unittest\TestCase {
     }');
   }
 
+  #[@beforeClass]
+  public static function makeConfigDirectory() {
+    self::$dir= realpath(System::tempDir()).md5(uniqid()).'.xp'.DIRECTORY_SEPARATOR;
+    if (is_dir(self::$dir) && !rmdir(self::$dir)) {
+      throw new PrerequisitesNotMetError('Fixture directory exists, but cannot remove', null, self::$dir);
+    }
+    self::$file= self::$dir.'web.ini';
+
+    mkdir(self::$dir);
+    file_put_contents(self::$file, '[app]');
+  }
+ 
+  #[@afterClass]
+  public function removeConfigDirectory() {
+    if (is_dir(self::$dir)) {
+      unlink(self::$file);
+      rmdir(self::$dir);
+    }
+  }
+
   #[@test]
   public function from_dash() {
     $this->assertInstanceOf('xp.scriptlet.ServeDocumentRootStatically', (new Source('-'))->layout());
@@ -27,31 +48,46 @@ class SourceTest extends \unittest\TestCase {
 
   #[@test]
   public function from_directory() {
-    $this->assertInstanceOf('xp.scriptlet.WebConfiguration', (new Source('etc'))->layout());
+    $this->assertInstanceOf('xp.scriptlet.WebConfiguration', (new Source(self::$dir))->layout());
+  }
+
+  #[@test]
+  public function from_file() {
+    $this->assertInstanceOf('xp.scriptlet.WebConfiguration', (new Source(self::$file))->layout());
   }
 
   #[@test]
   public function from_fully_qualified_scriptlet_name() {
-    $this->assertInstanceOf('xp.scriptlet.SingleScriptlet', (new Source(':'.self::$scriptlet->getName()))->layout());
+    $this->assertInstanceOf('xp.scriptlet.SingleScriptlet', (new Source(self::$scriptlet->getName()))->layout());
   }
 
   #[@test]
   public function from_fully_qualified_layout_name() {
+    $this->assertInstanceOf(self::$layout, (new Source(self::$layout->getName()))->layout());
+  }
+
+  #[@test]
+  public function from_fully_qualified_scriptlet_name_bc_with_colon_prefix() {
+    $this->assertInstanceOf('xp.scriptlet.SingleScriptlet', (new Source(':'.self::$scriptlet->getName()))->layout());
+  }
+
+  #[@test]
+  public function from_fully_qualified_layout_name_bc_with_colon_prefix() {
     $this->assertInstanceOf(self::$layout, (new Source(':'.self::$layout->getName()))->layout());
   }
 
-  #[@test, @expect(IllegalArgumentException::class)]
-  public function cannot_create_when_passed_class_which_is_neither_scriptlet_nor_layout() {
-    (new Source(':lang.Object'))->layout();
+  #[@test, @expect(IllegalArgumentException::class), @values(['lang.Object', ':lang.Object'])]
+  public function cannot_create_when_passed_class_which_is_neither_scriptlet_nor_layout($name) {
+    (new Source($name))->layout();
   }
 
-  #[@test, @expect(IllegalArgumentException::class)]
-  public function cannot_create_when_passed_class_does_not_exist() {
-    (new Source(':does.not.exist'))->layout();
+  #[@test, @expect(IllegalArgumentException::class), @values(['does.not.exist', ':does.not.exist'])]
+  public function cannot_create_when_passed_class_does_not_exist($name) {
+    (new Source($name))->layout();
   }
 
-  #[@test, @expect(IllegalArgumentException::class)]
-  public function cannot_create_when_passed_class_is_empty() {
-    (new Source(':'))->layout();
+  #[@test, @expect(IllegalArgumentException::class), @values(['', ':'])]
+  public function cannot_create_when_passed_class_is_empty($name) {
+    (new Source($name))->layout();
   }
 }

--- a/src/test/php/scriptlet/unittest/SourceTest.class.php
+++ b/src/test/php/scriptlet/unittest/SourceTest.class.php
@@ -2,20 +2,25 @@
 
 use lang\IllegalArgumentException;
 use xp\scriptlet\Source;
+use xp\scriptlet\ServeDocumentRootStatically;
+use xp\scriptlet\WebConfiguration;
+use xp\scriptlet\SingleScriptlet;
+use scriptlet\HttpScriptlet;
 use lang\ClassLoader;
 use lang\System;
+use lang\Object;
 
 class SourceTest extends \unittest\TestCase {
   private static $scriptlet, $layout, $dir, $file;
 
   #[@beforeClass]
   public static function defineScriptlet() {
-    self::$scriptlet= ClassLoader::defineClass('scriptlet.unittest.SourceTest_Scriptlet', 'scriptlet.HttpScriptlet', []);
+    self::$scriptlet= ClassLoader::defineClass(SourceTest_Scriptlet::class, HttpScriptlet::class, []);
   }
 
   #[@beforeClass]
   public static function defineLayout() {
-    self::$layout= ClassLoader::defineClass('scriptlet.unittest.SourceTest_Layout', 'lang.Object', ['xp.scriptlet.WebLayout'], '{
+    self::$layout= ClassLoader::defineClass(SourceTest_Layout::class, Object::class, ['xp.scriptlet.WebLayout'], '{
       public function mappedApplications($profile= null) { /* Intentionally empty */ }
       public function staticResources($profile= null) { /* Intentionally empty */ }
     }');
@@ -43,22 +48,22 @@ class SourceTest extends \unittest\TestCase {
 
   #[@test]
   public function from_dash() {
-    $this->assertInstanceOf('xp.scriptlet.ServeDocumentRootStatically', (new Source('-'))->layout());
+    $this->assertInstanceOf(ServeDocumentRootStatically::class, (new Source('-'))->layout());
   }
 
   #[@test]
   public function from_directory() {
-    $this->assertInstanceOf('xp.scriptlet.WebConfiguration', (new Source(self::$dir))->layout());
+    $this->assertInstanceOf(WebConfiguration::class, (new Source(self::$dir))->layout());
   }
 
   #[@test]
   public function from_file() {
-    $this->assertInstanceOf('xp.scriptlet.WebConfiguration', (new Source(self::$file))->layout());
+    $this->assertInstanceOf(WebConfiguration::class, (new Source(self::$file))->layout());
   }
 
   #[@test]
   public function from_fully_qualified_scriptlet_name() {
-    $this->assertInstanceOf('xp.scriptlet.SingleScriptlet', (new Source(self::$scriptlet->getName()))->layout());
+    $this->assertInstanceOf(SingleScriptlet::class, (new Source(self::$scriptlet->getName()))->layout());
   }
 
   #[@test]
@@ -68,7 +73,7 @@ class SourceTest extends \unittest\TestCase {
 
   #[@test]
   public function from_fully_qualified_scriptlet_name_bc_with_colon_prefix() {
-    $this->assertInstanceOf('xp.scriptlet.SingleScriptlet', (new Source(':'.self::$scriptlet->getName()))->layout());
+    $this->assertInstanceOf(SingleScriptlet::class, (new Source(':'.self::$scriptlet->getName()))->layout());
   }
 
   #[@test]

--- a/src/test/php/scriptlet/unittest/SourceTest.class.php
+++ b/src/test/php/scriptlet/unittest/SourceTest.class.php
@@ -23,7 +23,7 @@ class SourceTest extends \unittest\TestCase {
 
   #[@beforeClass]
   public static function makeConfigDirectory() {
-    self::$dir= realpath(System::tempDir()).md5(uniqid()).'.xp'.DIRECTORY_SEPARATOR;
+    self::$dir= realpath(System::tempDir()).DIRECTORY_SEPARATOR.md5(uniqid()).'.xp'.DIRECTORY_SEPARATOR;
     if (is_dir(self::$dir) && !rmdir(self::$dir)) {
       throw new PrerequisitesNotMetError('Fixture directory exists, but cannot remove', null, self::$dir);
     }

--- a/src/test/php/scriptlet/unittest/SourceTest.class.php
+++ b/src/test/php/scriptlet/unittest/SourceTest.class.php
@@ -5,6 +5,7 @@ use xp\scriptlet\Source;
 use xp\scriptlet\ServeDocumentRootStatically;
 use xp\scriptlet\WebConfiguration;
 use xp\scriptlet\SingleScriptlet;
+use xp\scriptlet\WebLayout;
 use scriptlet\HttpScriptlet;
 use lang\ClassLoader;
 use lang\System;
@@ -20,7 +21,7 @@ class SourceTest extends \unittest\TestCase {
 
   #[@beforeClass]
   public static function defineLayout() {
-    self::$layout= ClassLoader::defineClass(self::class.'_Layout', Object::class, ['xp.scriptlet.WebLayout'], '{
+    self::$layout= ClassLoader::defineClass(self::class.'_Layout', Object::class, [WebLayout::class], '{
       public function mappedApplications($profile= null) { /* Intentionally empty */ }
       public function staticResources($profile= null) { /* Intentionally empty */ }
     }');

--- a/src/test/php/scriptlet/unittest/SourceTest.class.php
+++ b/src/test/php/scriptlet/unittest/SourceTest.class.php
@@ -15,12 +15,12 @@ class SourceTest extends \unittest\TestCase {
 
   #[@beforeClass]
   public static function defineScriptlet() {
-    self::$scriptlet= ClassLoader::defineClass(SourceTest_Scriptlet::class, HttpScriptlet::class, []);
+    self::$scriptlet= ClassLoader::defineClass(self::class.'_Scriptlet', HttpScriptlet::class, []);
   }
 
   #[@beforeClass]
   public static function defineLayout() {
-    self::$layout= ClassLoader::defineClass(SourceTest_Layout::class, Object::class, ['xp.scriptlet.WebLayout'], '{
+    self::$layout= ClassLoader::defineClass(self::class.'_Layout', Object::class, ['xp.scriptlet.WebLayout'], '{
       public function mappedApplications($profile= null) { /* Intentionally empty */ }
       public function staticResources($profile= null) { /* Intentionally empty */ }
     }');

--- a/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
+++ b/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
@@ -1,14 +1,25 @@
 <?php namespace scriptlet\unittest;
 
-use unittest\TestCase;
+use util\RegisteredPropertySource;
 use xp\scriptlet\WebConfiguration;
+use xp\scriptlet\Config;
 
 /**
  * TestCase
  *
  * @see   xp://xp.scriptlet.WebConfiguration
  */
-class WebConfigurationTest extends TestCase {
+class WebConfigurationTest extends \unittest\TestCase {
+
+  /**
+   * Creates a web configuration instance
+   *
+   * @param  util.Properties $properties
+   * @return xp.scriptlet.WebConfiguration
+   */
+  private function newConfiguration($properties) {
+    return new WebConfiguration($properties, new Config([]));
+  }
 
   #[@test]
   public function configure_with_all_possible_settings() {
@@ -33,7 +44,7 @@ class WebConfigurationTest extends TestCase {
           ->withDebug(\xp\scriptlet\WebDebug::STACKTRACE | \xp\scriptlet\WebDebug::ERRORS)
           ->withArguments(['a', 'b'])
         ],
-        (new WebConfiguration($p))->mappedApplications('dev')
+        $this->newConfiguration($p)->mappedApplications('dev')
       );
     }
   }
@@ -46,7 +57,7 @@ class WebConfigurationTest extends TestCase {
       $p->writeSection('app::service');
       $p->writeString('app::service', 'debug', 'UNKNOWN');
 
-      (new WebConfiguration($p))->mappedApplications();
+      $this->newConfiguration($p)->mappedApplications();
     }
   }
 
@@ -55,7 +66,7 @@ class WebConfigurationTest extends TestCase {
     with ($p= \util\Properties::fromString('')); {
       $p->writeSection('app');
 
-      (new WebConfiguration($p))->mappedApplications();
+      $this->newConfiguration($p)->mappedApplications();
     }
   }
 
@@ -65,7 +76,7 @@ class WebConfigurationTest extends TestCase {
       $p->writeSection('app');
       $p->writeString('app', 'not.a.mapping', 1);
 
-      (new WebConfiguration($p))->mappedApplications();
+      $this->newConfiguration($p)->mappedApplications();
     }
   }
 
@@ -83,7 +94,7 @@ class WebConfigurationTest extends TestCase {
           '/service' => (new \xp\scriptlet\WebApplication('service'))->withConfig('{WEBROOT}/etc'), 
           '/'        => (new \xp\scriptlet\WebApplication('global'))->withConfig('{WEBROOT}/etc')
         ],
-        (new WebConfiguration($p))->mappedApplications()
+        $this->newConfiguration($p)->mappedApplications()
       );
     }
   }
@@ -94,7 +105,7 @@ class WebConfigurationTest extends TestCase {
       $p->writeSection('app');
       $p->writeString('app', 'mappings', '/service:service');
 
-      (new WebConfiguration($p))->mappedApplications();
+      $this->newConfiguration($p)->mappedApplications();
     }
   }
 
@@ -113,7 +124,7 @@ class WebConfigurationTest extends TestCase {
           '/service' => (new \xp\scriptlet\WebApplication('service'))->withConfig('{WEBROOT}/etc'), 
           '/'        => (new \xp\scriptlet\WebApplication('global'))->withConfig('{WEBROOT}/etc')
         ],
-        (new WebConfiguration($p))->mappedApplications()
+        $this->newConfiguration($p)->mappedApplications()
       );
     }
   }
@@ -124,7 +135,7 @@ class WebConfigurationTest extends TestCase {
       $p->writeSection('app');
       $p->writeString('app', 'map.service', '/service');
 
-      (new WebConfiguration($p))->mappedApplications();
+      $this->newConfiguration($p)->mappedApplications();
     }
   }
 }

--- a/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
+++ b/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
@@ -3,6 +3,8 @@
 use util\RegisteredPropertySource;
 use xp\scriptlet\WebConfiguration;
 use xp\scriptlet\Config;
+use scriptlet\HttpScriptlet;
+use lang\ClassLoader;
 
 /**
  * TestCase
@@ -10,6 +12,12 @@ use xp\scriptlet\Config;
  * @see   xp://xp.scriptlet.WebConfiguration
  */
 class WebConfigurationTest extends \unittest\TestCase {
+  private static $scriptlet;
+
+  #[@beforeClass]
+  public static function defineScriptlet() {
+    self::$scriptlet= ClassLoader::defineClass(self::class.'_Scriptlet', HttpScriptlet::class, [], []);
+  }
 
   /**
    * Creates a web configuration instance
@@ -28,7 +36,7 @@ class WebConfigurationTest extends \unittest\TestCase {
       $p->writeString('app', 'map.service', '/service');
 
       $p->writeSection('app::service');
-      $p->writeString('app::service', 'class', 'ServiceScriptlet');
+      $p->writeString('app::service', 'class', self::$scriptlet);
       $p->writeString('app::service', 'prop-base', '{WEBROOT}/etc/{PROFILE}');
       $p->writeString('app::service', 'init-envs', 'ROLE:admin|CLUSTER:a');
       $p->writeString('app::service', 'init-params', 'a|b');
@@ -39,7 +47,7 @@ class WebConfigurationTest extends \unittest\TestCase {
       $this->assertEquals(
         ['/service' => (new \xp\scriptlet\WebApplication('service'))
           ->withConfig('{WEBROOT}/etc/{PROFILE}')
-          ->withScriptlet('ServiceScriptlet')
+          ->withScriptlet(self::$scriptlet)
           ->withEnvironment(['ROLE' => 'admin', 'CLUSTER' => 'a'])
           ->withDebug(\xp\scriptlet\WebDebug::STACKTRACE | \xp\scriptlet\WebDebug::ERRORS)
           ->withArguments(['a', 'b'])

--- a/src/test/resources/user/debug.ini
+++ b/src/test/resources/user/debug.ini
@@ -1,0 +1,2 @@
+[section]
+key=value


### PR DESCRIPTION
## XP "web" command
The `-c` option accepts either file names or directory names and will add these to the configuration sources.

```sh
# Use a layout
$ xp web -c etc/prod name.of.WebLayout

# BC: Use a web.ini
$ xp web -c etc/prod etc/web.ini
```

## XPWS from legacy XP runners
The `-c` option may now include additional config paths:

```sh
# Use a layout
$ xpws -c name.of.WebLayout:etc/prod

# BC: Use a web.ini
$ xpws -c etc/web.ini:etc/prod
```

## Web runner
When running inside a web container, you can use the `user_dir` directive to pass the configuration sources by appending paths (*in the example below, `~/etc/prod`*):

```xml
<VirtualHost ...>
  DocumentRoot /opt/webs/app/static

  RewriteEngine on
  RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} !-f
  RewriteRule ^/ /usr/bin/web-main.php

  php_value include_path ~/vendor/autoload.php

  # Use a layout
  php_value user_dir name.of.WebLayout:~/etc/prod

  # BC: Use a web.ini
  php_value user_dir ~/etc/web.ini:~/etc/prod
</VirtualHost>
```

## Config API
```php
public class xp.scriptlet.Config implements lang.Value {
  private var $sources

  public __construct(string[]|util.PropertySource[] $sources)

  public void append(string|util.PropertySource $source)
  public bool isEmpty()
  public util.PropertySource[] sources()
  public util.PropertyAccess properties(string $name)
  public int compareTo(var $value)
  public string hashCode()
  public string toString()
}
```

## Accessing config in layouts
Web layout implementations will be instantiated with the configuration passed to their constructor.

## Accessing config in scriptlets
The configuration can be passed to scriptlets via their constructor arguments:

```php
class Configurable implements WebLayout {
  private $config;

  public function __construct($config) {
    $this->config= $config;
  }

  public function mappedApplications($profile= null) {
    return ['/' => (new WebApplication('test'))
      ->withScriptlet(TestScriptlet::class)
      ->withArguments([$this->config])
    ];
  }

  public function staticResources($profile= null) {
    return null;
  }
}
```