### PR TITLE
Configurable log level for scriptlet exceptions

### DIFF
--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -1,6 +1,5 @@
 <?php namespace xp\scriptlet;
 
-use lang\IllegalArgumentException;
 use scriptlet\ScriptletException;
 use util\Properties;
 use util\PropertyManager;
@@ -239,17 +238,8 @@ class Runner extends \lang\Object {
       // Service
       $instance->service($request, $response);
     } catch (ScriptletException $e) {
-
       if (isset($application->logLevels()[$e->getStatus()])) {
         $logLevel= $application->logLevels()[$e->getStatus()];
-        if (!method_exists($cat, $logLevel)) {
-          throw new IllegalArgumentException(sprintf(
-            'Invalid log level "%s" configured for status code %d of application "%s"',
-            $logLevel,
-            $e->getStatus(),
-            $application->name()
-          ));
-        }
         $cat->{$logLevel}($e);
       } else {
         $cat->error($e);

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -240,7 +240,7 @@ class Runner extends \lang\Object {
 
       if (isset($application->logLevels()[$e->getStatus()])) {
         $logLevel= $application->logLevels()[$e->getStatus()];
-        $cat->$logLevel($e);
+        $cat->{$logLevel}($e);
       } else {
         $cat->error($e);
       }

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -237,7 +237,13 @@ class Runner extends \lang\Object {
       // Service
       $instance->service($request, $response);
     } catch (\scriptlet\ScriptletException $e) {
-      $cat->error($e);
+
+      if (isset($application->logLevels()[$e->getStatus()])) {
+        $logLevel= $application->logLevels()[$e->getStatus()];
+        $cat->$logLevel($e);
+      } else {
+        $cat->error($e);
+      }
 
       // TODO: Instead of checking for a certain method, this should
       // check if the scriptlet class implements a certain interface

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -1,5 +1,7 @@
 <?php namespace xp\scriptlet;
 
+use lang\IllegalArgumentException;
+use scriptlet\ScriptletException;
 use util\Properties;
 use util\PropertyManager;
 use util\RegisteredPropertySource;
@@ -236,10 +238,18 @@ class Runner extends \lang\Object {
 
       // Service
       $instance->service($request, $response);
-    } catch (\scriptlet\ScriptletException $e) {
+    } catch (ScriptletException $e) {
 
       if (isset($application->logLevels()[$e->getStatus()])) {
         $logLevel= $application->logLevels()[$e->getStatus()];
+        if (!method_exists($cat, $logLevel)) {
+          throw new IllegalArgumentException(sprintf(
+            'Invalid log level "%s" configured for status code %d of application "%s"',
+            $logLevel,
+            $e->getStatus(),
+            $application->name()
+          ));
+        }
         $cat->{$logLevel}($e);
       } else {
         $cat->error($e);

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -210,7 +210,7 @@ class WebApplication extends \lang\Object {
   /**
    * Returns log level configuration for scriptlet exceptions
    *
-   * @return array
+   * @return string[]
    */
   public function logLevels() {
     return $this->logLevels;

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -218,6 +218,7 @@ class WebApplication extends \lang\Object {
       "  [debug        ] %s\n".
       "  [arguments    ] [%s]\n".
       "  [environment  ] %s\n".
+      "  [logLevels  ] %s\n".
       "}",
       nameof($this),
       $this->name,
@@ -225,7 +226,8 @@ class WebApplication extends \lang\Object {
       $this->scriptlet ? $this->scriptlet->getName() : '(none)',
       implode(' | ', WebDebug::namesOf($this->debug)),
       implode(', ', $this->arguments),
-      \xp::stringOf($this->environment, '  ')
+      \xp::stringOf($this->environment, '  '),
+      \xp::stringOf($this->logLevels(), '  ')
     );
   }
   
@@ -243,6 +245,7 @@ class WebApplication extends \lang\Object {
       $this->arguments === $cmp->arguments &&
       $this->environment === $cmp->environment &&
       $this->scriptlet === null ? null === $cmp->scriptlet : $this->scriptlet->equals($cmp->scriptlet) &&
+      $this->logLevels === $cmp->logLevels &&
       0 === $this->config->compareTo($cmp->config)
     );
   }

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -2,6 +2,7 @@
 
 use scriptlet\Filter;
 use lang\XPClass;
+use util\Objects;
 
 /**
  * Represents a web application
@@ -245,7 +246,7 @@ class WebApplication extends \lang\Object {
       $this->arguments === $cmp->arguments &&
       $this->environment === $cmp->environment &&
       $this->scriptlet === null ? null === $cmp->scriptlet : $this->scriptlet->equals($cmp->scriptlet) &&
-      $this->logLevels === $cmp->logLevels &&
+      Objects::equal($this->logLevels, $cmp->logLevels) &&
       0 === $this->config->compareTo($cmp->config)
     );
   }

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -17,6 +17,7 @@ class WebApplication extends \lang\Object {
   protected $filters = [];
   protected $environment = [];
   protected $debug = 0;
+  protected $logLevels = [];
 
   /**
    * Creates a new web application named by the given name
@@ -182,7 +183,28 @@ class WebApplication extends \lang\Object {
   public function environment() {
     return $this->environment;
   }
-  
+
+  /**
+   * Sets log level for specific scriptlet exceptions
+   *
+   * @param int $httpStatusCode
+   * @param string $logLevel
+   * @return self this
+   */
+  public function withLogLevel($httpStatusCode, $logLevel) {
+    $this->logLevels[$httpStatusCode]= $logLevel;
+    return $this;
+  }
+
+  /**
+   * Returns log level configuration for scriptlet exceptions
+   *
+   * @return array
+   */
+  public function logLevels() {
+    return $this->logLevels;
+  }
+
   /**
    * Creates a string representation of this object
    *

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -3,6 +3,8 @@
 use scriptlet\Filter;
 use lang\XPClass;
 use util\Objects;
+use util\log\LogCategory;
+use lang\IllegalArgumentException;
 
 /**
  * Represents a web application
@@ -193,6 +195,14 @@ class WebApplication extends \lang\Object {
    * @return self this
    */
   public function withLogLevel($httpStatusCode, $logLevel) {
+    if (!method_exists(LogCategory::class, $logLevel)) {
+      throw new IllegalArgumentException(sprintf(
+        'Invalid log level "%s" configured for status code %d of application "%s"',
+        $logLevel,
+        $httpStatusCode,
+        $this->name()
+      ));
+    }
     $this->logLevels[$httpStatusCode]= $logLevel;
     return $this;
   }

--- a/src/main/php/xp/scriptlet/WebConfiguration.class.php
+++ b/src/main/php/xp/scriptlet/WebConfiguration.class.php
@@ -118,6 +118,12 @@ class WebConfiguration extends \lang\Object implements WebLayout {
     foreach ($this->readArray($profile, $section, 'filters', []) as $filter) {
       $app->withFiter($filter);
     }
+
+    // Log levels for http status codes
+    $logLevels= $this->readMap($profile, $section, 'log-level', []);
+    foreach ($logLevels as $httpStatusCode => $logLevel) {
+      $app->withLogLevel($httpStatusCode, $logLevel);
+    }
    
     return $app;
   }

--- a/src/test/php/scriptlet/unittest/RunnerTest.class.php
+++ b/src/test/php/scriptlet/unittest/RunnerTest.class.php
@@ -193,6 +193,12 @@ class RunnerTest extends TestCase {
       ->withLogLevel(HttpConstants::STATUS_NOT_FOUND, 'warn')
     );
 
+    // The not found application with invvalid error level level
+    $r->mapApplication('/notfoundinvalidlevel', (new WebApplication('notfoundinvalidlevel'))
+      ->withScriptlet(self::$notFoundScriptlet->getName())
+      ->withLogLevel(HttpConstants::STATUS_NOT_FOUND, 'invalid')
+    );
+
     // The welcome application
     $r->mapApplication('/', (new \xp\scriptlet\WebApplication('welcome'))
       ->withScriptlet(self::$welcomeScriptlet->getName())
@@ -469,6 +475,11 @@ class RunnerTest extends TestCase {
     $this->assertContained('warn] Exception', $buffer);
 
     $cat->removeAppender($appender);
+  }
+
+  #[@test, @expect(class= 'lang.IllegalArgumentException', withMessage= 'Invalid log level "invalid" configured for status code 404 of application "notfoundinvalidlevel"')]
+  public function notFoundInvalidExceptionLevel() {
+    $this->runWith('dev', '/notfoundinvalidlevel');
   }
 
   #[@test]

--- a/src/test/php/scriptlet/unittest/RunnerTest.class.php
+++ b/src/test/php/scriptlet/unittest/RunnerTest.class.php
@@ -193,12 +193,6 @@ class RunnerTest extends TestCase {
       ->withLogLevel(HttpConstants::STATUS_NOT_FOUND, 'warn')
     );
 
-    // The not found application with invvalid error level level
-    $r->mapApplication('/notfoundinvalidlevel', (new WebApplication('notfoundinvalidlevel'))
-      ->withScriptlet(self::$notFoundScriptlet->getName())
-      ->withLogLevel(HttpConstants::STATUS_NOT_FOUND, 'invalid')
-    );
-
     // The welcome application
     $r->mapApplication('/', (new \xp\scriptlet\WebApplication('welcome'))
       ->withScriptlet(self::$welcomeScriptlet->getName())
@@ -475,11 +469,6 @@ class RunnerTest extends TestCase {
     $this->assertContained('warn] Exception', $buffer);
 
     $cat->removeAppender($appender);
-  }
-
-  #[@test, @expect(class= 'lang.IllegalArgumentException', withMessage= 'Invalid log level "invalid" configured for status code 404 of application "notfoundinvalidlevel"')]
-  public function notFoundInvalidExceptionLevel() {
-    $this->runWith('dev', '/notfoundinvalidlevel');
   }
 
   #[@test]

--- a/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
+++ b/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
@@ -49,6 +49,7 @@ class WebConfigurationTest extends \unittest\TestCase {
       $p->writeString('app::service', 'prop-base', '{WEBROOT}/etc/{PROFILE}');
       $p->writeString('app::service', 'init-envs', 'ROLE:admin|CLUSTER:a');
       $p->writeString('app::service', 'init-params', 'a|b');
+      $p->writeHash('app::service', 'log-level', [404 => 'warn', 403 => 'error']);
 
       $p->writeSection('app::service@dev');
       $p->writeString('app::service@dev', 'debug', 'STACKTRACE|ERRORS');
@@ -60,6 +61,8 @@ class WebConfigurationTest extends \unittest\TestCase {
           ->withEnvironment(['ROLE' => 'admin', 'CLUSTER' => 'a'])
           ->withDebug(\xp\scriptlet\WebDebug::STACKTRACE | \xp\scriptlet\WebDebug::ERRORS)
           ->withArguments(['a', 'b'])
+          ->withLogLevel(404, 'warn')
+          ->withLogLevel(403, 'error')
         ],
         $this->newConfiguration($p)->mappedApplications('dev')
       );

--- a/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
+++ b/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace scriptlet\unittest;
 
 use util\RegisteredPropertySource;
+use xp\scriptlet\WebApplication;
 use xp\scriptlet\WebConfiguration;
 use xp\scriptlet\Config;
 use scriptlet\HttpScriptlet;
@@ -67,6 +68,12 @@ class WebConfigurationTest extends \unittest\TestCase {
         $this->newConfiguration($p)->mappedApplications('dev')
       );
     }
+  }
+
+  #[@test, @expect(class= 'lang.IllegalArgumentException', withMessage= 'Invalid log level "invalid" configured for status code 404 of application "test"')]
+  public function configure_with_invalid_loglevel() {
+    (new WebApplication('test'))
+      ->withLogLevel(404, 'invalid');
   }
 
   #[@test, @expect(class= 'lang.IllegalArgumentException', withMessage= 'No flag named WebDebug::UNKNOWN')]

--- a/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
+++ b/src/test/php/scriptlet/unittest/WebConfigurationTest.class.php
@@ -49,7 +49,7 @@ class WebConfigurationTest extends \unittest\TestCase {
       $p->writeString('app::service', 'prop-base', '{WEBROOT}/etc/{PROFILE}');
       $p->writeString('app::service', 'init-envs', 'ROLE:admin|CLUSTER:a');
       $p->writeString('app::service', 'init-params', 'a|b');
-      $p->writeHash('app::service', 'log-level', [404 => 'warn', 403 => 'error']);
+      $p->writeMap('app::service', 'log-level', [404 => 'warn', 403 => 'error']);
 
       $p->writeSection('app::service@dev');
       $p->writeString('app::service@dev', 'debug', 'STACKTRACE|ERRORS');


### PR DESCRIPTION
This change enables the configration of the log level used when logging scriptlet exceptions.

Example configuration in the web.ini:
```ini
[app::home]
log-level[404]="info"
log-level[403]="warn"
```

