### PR TITLE
Add xp-forge/web adapter

### DIFF
--- a/src/main/php/scriptlet/Run.class.php
+++ b/src/main/php/scriptlet/Run.class.php
@@ -1,0 +1,63 @@
+<?php namespace scriptlet;
+
+/**
+ * Adapter class for new web API
+ *
+ * @see  https://github.com/xp-forge/web
+ */
+class Run implements \web\Handler {
+
+  /**
+   * Creates a new scriptlet runner
+   *
+   * @param  scriptlet.HttpScriptlet $scriptlet
+   */
+  public function __construct(HttpScriptlet $scriptlet) {
+    $this->scriptlet= $scriptlet;
+    $this->scriptlet->init();
+  }
+
+  public function handle($request, $response) {
+    with ($req= $this->scriptlet->request(), $res= $this->scriptlet->response()); {
+      $uri= $request->uri();
+      $port= $uri->getPort(-1);
+
+      // Proxy request
+      $req->url= new HttpScriptletURL($uri->getURL());
+      $req->method= $request->method();
+      $req->env= [
+        'SERVER_PROTOCOL' => 'HTTP/1.1',
+        'REQUEST_URI'     => $uri->getPath(),
+        'QUERY_STRING'    => $uri->getQuery(),
+        'HTTP_HOST'       => $uri->getHost().(-1 === $port ? '' : ':'.$port)
+      ];
+      $req->setParams($request->params());
+      $req->setHeaders(array_merge($request->headers(), $request->values()));
+      $req->readData= function() use($request) {
+        // TBI
+      };
+
+      // Proxy response
+      $res->sendHeaders= function($version, $statusCode, $headers) use($response) {
+        $response->answer($statusCode);
+        foreach ($headers as $header) {
+          sscanf($header, "%[^:]: %[^\r]", $name, $value);
+          $response->header($name, $value);
+        }
+      };
+      $res->sendContent= function($content) use($response) {
+        $response->write($content);
+      };
+
+      // Run scriptlet
+      try {
+        $this->scriptlet->service($req, $res);
+      } catch (ScriptletException $e) {
+        throw new InternalServerError($e);
+      }
+
+      $res->isCommitted() || $res->flush();
+      $res->sendContent();
+    }
+  }
+}

--- a/src/main/php/scriptlet/Run.class.php
+++ b/src/main/php/scriptlet/Run.class.php
@@ -44,13 +44,14 @@ class Run implements \web\Handler {
       $req->setParams($request->params());
       $req->setHeaders(array_merge($request->headers(), $request->values()));
       $req->readData= function() use($request) {
-        // TBI
+        return $request->read(-1);
       };
 
       // Proxy response
       $stream= null;
       $res->sendHeaders= function($version, $statusCode, $headers) use($response, &$stream) {
         $response->answer($statusCode);
+
         foreach ($headers as $header) {
           sscanf($header, "%[^:]: %[^\r]", $name, $value);
           if (0 === strcasecmp('Content-Length', $name)) {

--- a/src/main/php/scriptlet/Run.class.php
+++ b/src/main/php/scriptlet/Run.class.php
@@ -1,5 +1,9 @@
 <?php namespace scriptlet;
 
+use web\InternalServerError;
+use web\Error;
+use lang\Throwable;
+
 /**
  * Adapter class for new web API
  *
@@ -17,19 +21,25 @@ class Run implements \web\Handler {
     $this->scriptlet->init();
   }
 
+  /**
+   * Handler
+   *
+   * @param  web.Request $request
+   * @param  web.Response $response
+   */
   public function handle($request, $response) {
     with ($req= $this->scriptlet->request(), $res= $this->scriptlet->response()); {
       $uri= $request->uri();
-      $port= $uri->getPort(-1);
+      $port= $uri->port() ?: -1;
 
       // Proxy request
-      $req->url= new HttpScriptletURL($uri->getURL());
+      $req->url= new HttpScriptletURL($uri->asString(true));
       $req->method= $request->method();
       $req->env= [
         'SERVER_PROTOCOL' => 'HTTP/1.1',
-        'REQUEST_URI'     => $uri->getPath(),
-        'QUERY_STRING'    => $uri->getQuery(),
-        'HTTP_HOST'       => $uri->getHost().(-1 === $port ? '' : ':'.$port)
+        'REQUEST_URI'     => $uri->path(true),
+        'QUERY_STRING'    => $uri->query(true),
+        'HTTP_HOST'       => $uri->host().(-1 === $port ? '' : ':'.$port)
       ];
       $req->setParams($request->params());
       $req->setHeaders(array_merge($request->headers(), $request->values()));
@@ -38,26 +48,36 @@ class Run implements \web\Handler {
       };
 
       // Proxy response
-      $res->sendHeaders= function($version, $statusCode, $headers) use($response) {
+      $stream= null;
+      $res->sendHeaders= function($version, $statusCode, $headers) use($response, &$stream) {
         $response->answer($statusCode);
         foreach ($headers as $header) {
           sscanf($header, "%[^:]: %[^\r]", $name, $value);
+          if (0 === strcasecmp('Content-Length', $name)) {
+            $stream= $response->stream($value);
+          }
           $response->header($name, $value);
         }
+
+        // Fall back to chunked encoding
+        if (null === $stream) $stream= $response->stream(null);
       };
-      $res->sendContent= function($content) use($response) {
-        $response->write($content);
+      $res->sendContent= function($content) use(&$stream) {
+        $stream->write($content);
       };
 
       // Run scriptlet
       try {
         $this->scriptlet->service($req, $res);
       } catch (ScriptletException $e) {
-        throw new InternalServerError($e);
+        throw new Error($e->getStatus(), $e->getMessage(), $e);
+      } catch (Throwable $t) {
+        throw new InternalServerError($t);
       }
 
       $res->isCommitted() || $res->flush();
       $res->sendContent();
+      $stream->close();
     }
   }
 }

--- a/src/test/php/scriptlet/unittest/HttpSessionTest.class.php
+++ b/src/test/php/scriptlet/unittest/HttpSessionTest.class.php
@@ -101,10 +101,10 @@ class HttpSessionTest extends TestCase {
   #[@test]
   public function putDoesNotOverwriteValue() {
     $this->session->initialize(null);
-    $fixture= new \lang\Object();
+    $fixture= new Date();
     $hash= $fixture->hashCode();
     $this->session->putValue('foo', $fixture);
-    $this->assertInstanceOf('lang.Object', $fixture);
+    $this->assertInstanceOf(Date::class, $fixture);
     $this->assertEquals($hash, $fixture->hashCode());
   }
   


### PR DESCRIPTION
This pull request adds an adapter class, `scriptlet.Run`, to run scriptlets in the new [xp-forge/web](https://github.com/xp-forge/web) API:

```php
<?php namespace com\example\rest;

use scriptlet\Run;
use webservices\rest\srv\RestScriptlet;

class Api extends \web\Application {

  /** @return [:var] */
  public function routes() {
    return [
      '/' => new Run(new RestScriptlet('com.example.rest.api', '/'))
    ];
  }
}