### PR TITLE
Fix for global exception handling.

### DIFF
--- a/src/main/php/scriptlet/AuthenticationFilter.class.php
+++ b/src/main/php/scriptlet/AuthenticationFilter.class.php
@@ -34,11 +34,11 @@ class AuthenticationFilter extends \lang\Object implements Filter {
   public function filter($request, $response, $invocation) {
     try {
       $r= $this->auth->authenticate($request, $response, null);
-      return false === $r ? $r : $invocation->proceed($request, $response);
     } catch (ScriptletException $e) {
       throw $e;
     } catch (Throwable $e) {
       throw new ScriptletException('Authentication failed: '.$e->getMessage(), HttpConstants::STATUS_FORBIDDEN, $e);
     }
+    return false === $r ? $r : $invocation->proceed($request, $response);
   }
 }

--- a/src/test/php/scriptlet/unittest/AuthenticationFilterTest.class.php
+++ b/src/test/php/scriptlet/unittest/AuthenticationFilterTest.class.php
@@ -1,0 +1,33 @@
+<?php namespace scriptlet\unittest;
+
+use lang\IllegalAccessException;
+use lang\IllegalArgumentException;
+use scriptlet\AuthenticationFilter;
+use scriptlet\Invocation;
+use unittest\TestCase;
+
+/**
+ * TestCase
+ *
+ * @see   xp://scriptlet.AuthenticationFilter
+ */
+class AuthenticationFilterTest extends TestCase {
+
+  /**
+   * Regression test for fixed error handling in pull request #22
+   * https://github.com/xp-framework/scriptlet/pull/22
+   */
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function fix_global_error_handling_regression() {
+    $mockAuthenticator= newinstance('scriptlet.RequestAuthenticator', [], [
+      'authenticate' => function($request, $response, $context) {
+        return true;
+      }
+    ]);
+    $mockInvocation= new Invocation(function() {
+      throw new IllegalArgumentException('Test');
+    }, [new AuthenticationFilter($mockAuthenticator)]);
+    $mockInvocation->proceed(null, null);
+  }
+
+}


### PR DESCRIPTION
Since in the end, the handler is called by this function:
```return false === $r ? $r : $invocation->proceed($request, $response);```
Every unhandled exception thrown in the handler will be converted into an ScriptletException with the "forbidden" error code.
This breaks the global error handling.

As a solution, I moved the call to an position outside of the try..catch block, in the assumtion that the error handling only is relevant for the "authenticate" call.