### PR TITLE
XP9 Compatibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 Scriptlets for the XP Framework ChangeLog
 ========================================================================
 
+## ?.?.? / ????-??-??
+
+## 8.0.0 / 2017-06-19
+
+* **Heads up:** Drop PHP 5.5 support - @thekid
+* Added forward compatibility with XP 9.0.0 - @thekid
+
 ## 8.4.6 / 2017-05-20
 
 * Refactored code to use `typeof()` instead of `xp::typeOf()`, see

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Scriptlets for the XP Framework
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-framework/scriptlet.png)](http://travis-ci.org/xp-framework/scriptlet)
 [![XP Framework Module](https://raw.githubusercontent.com/xp-framework/web/master/static/xp-framework-badge.png)](https://github.com/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
-[![Required PHP 5.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_5plus.png)](http://php.net/)
+[![Required PHP 5.6+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_6plus.png)](http://php.net/)
 [![Supports PHP 7.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-7_0plus.png)](http://php.net/)
 [![Latest Stable Version](https://poser.pugx.org/xp-framework/scriptlet/version.png)](https://packagist.org/packages/xp-framework/scriptlet)
 

--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,17 @@
   "description" : "Scriptlets for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
-    "xp-framework/http": "^8.0 | ^7.0 | ^6.2",
-    "xp-framework/xml": "^8.0 |^7.0 | ^6.3",
-    "xp-framework/rdbms": "^9.0 | ^8.0 | ^7.0 | ^6.5",
-    "xp-framework/mail": "^7.0 | ^6.1",
-    "xp-framework/logging": "^7.0 | ^6.5",
-    "xp-framework/networking": "^8.0 | ^7.0 | ^6.6",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
+    "xp-framework/http": "^9.0 | ^8.0 | ^7.0 | ^6.2",
+    "xp-framework/xml": "^9.0 | ^8.0 |^7.0 | ^6.3",
+    "xp-framework/rdbms": "^10.0 | ^9.0 | ^8.0 | ^7.0 | ^6.5",
+    "xp-framework/mail": "^8.0 | ^7.0 | ^6.1",
+    "xp-framework/logging": "^8.0 | ^7.0 | ^6.5",
+    "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
     "php": ">=5.5.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | 7.0 | ^6.5"
   },
   "bin": ["bin/xp.xp-framework.scriptlet.web"],
   "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "xp-framework/mail": "^8.0 | ^7.0 | ^6.1",
     "xp-framework/logging": "^8.0 | ^7.0 | ^6.5",
     "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
-    "php": ">=5.5.0"
+    "php": ">=5.6.0"
   },
   "require-dev" : {
     "xp-framework/unittest": "^9.0 | ^8.0 | 7.0 | ^6.5"

--- a/src/main/php/scriptlet/AuthenticationFilter.class.php
+++ b/src/main/php/scriptlet/AuthenticationFilter.class.php
@@ -9,7 +9,7 @@ use peer\http\HttpConstants;
  * @see   xp://scriptlet.HttpScriptlet#getAuthenticator
  * @test  xp://scriptlet.unittest.RequestAuthenticatorTest
  */
-class AuthenticationFilter extends \lang\Object implements Filter {
+class AuthenticationFilter implements Filter {
   private $auth;
 
   /**

--- a/src/main/php/scriptlet/Cookie.class.php
+++ b/src/main/php/scriptlet/Cookie.class.php
@@ -25,7 +25,7 @@ use util\Date;
  * @test     xp://scriptlet.unittest.CookieTest
  * @purpose  Cookie header
  */
-class Cookie extends \lang\Object {
+class Cookie {
   public 
     $name         = '',
     $value        = '',

--- a/src/main/php/scriptlet/ErrorDocument.class.php
+++ b/src/main/php/scriptlet/ErrorDocument.class.php
@@ -44,7 +44,7 @@ use io\File;
  * @deprecated  Now handled by scriptlet runner
  * @see scriptlet.HttpScriptlet
  */
-class ErrorDocument extends \lang\Object {
+class ErrorDocument {
   public 
     $statusCode,
     $language,

--- a/src/main/php/scriptlet/HttpScriptlet.class.php
+++ b/src/main/php/scriptlet/HttpScriptlet.class.php
@@ -31,7 +31,7 @@ use peer\http\HttpConstants;
  * @test   xp://scriptlet.unittest.HttpScriptletTest
  * @test   xp://scriptlet.unittest.HttpScriptletProcessTest
  */
-class HttpScriptlet extends \lang\Object {
+class HttpScriptlet {
   private $filters= [];
   
   /**

--- a/src/main/php/scriptlet/HttpScriptletRequest.class.php
+++ b/src/main/php/scriptlet/HttpScriptletRequest.class.php
@@ -12,7 +12,7 @@ use io\streams\ChannelInputStream;
  * @test  xp://scriptlet.unittest.HttpScriptletRequestTest
  * @see   xp://scriptlet.HttpScriptlet
  */  
-class HttpScriptletRequest extends \lang\Object implements Request {
+class HttpScriptletRequest implements Request {
   public
     $url=             null,
     $env=             [],

--- a/src/main/php/scriptlet/HttpScriptletResponse.class.php
+++ b/src/main/php/scriptlet/HttpScriptletResponse.class.php
@@ -13,7 +13,7 @@ use peer\http\HttpConstants;
  * @see      xp://scriptlet.HttpScriptlet
  * @purpose  Provide a way to access the HTTP response
  */  
-class HttpScriptletResponse extends \lang\Object implements Response {
+class HttpScriptletResponse implements Response {
   protected
     $uri=             null,
     $committed=       false,

--- a/src/main/php/scriptlet/HttpSession.class.php
+++ b/src/main/php/scriptlet/HttpSession.class.php
@@ -28,7 +28,7 @@ define('SESS_CREATE',    '__PHP_SessionCreatedAt');
  * @test    xp://scriptlet.unittest.HttpSessionTest
  * @purpose Session implementation                                                    
  */
-class HttpSession extends \lang\Object implements Session {
+class HttpSession implements Session {
   public 
     $id    = '',
     $isNew = false;

--- a/src/main/php/scriptlet/Invocation.class.php
+++ b/src/main/php/scriptlet/Invocation.class.php
@@ -3,7 +3,7 @@
 /**
  * HTTP service handler invocation
  */  
-class Invocation extends \lang\Object {
+class Invocation {
   private $handler;
   private $chain;
 

--- a/src/main/php/scriptlet/LocaleNegotiator.class.php
+++ b/src/main/php/scriptlet/LocaleNegotiator.class.php
@@ -49,7 +49,7 @@ use util\Locale;
  * @test   xp://scriptlet.unittest.LocaleNegotiatorTest
  * @see    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
  */
-class LocaleNegotiator extends \lang\Object {
+class LocaleNegotiator {
   public $languages;
   public $charsets;
 

--- a/src/main/php/scriptlet/Preference.class.php
+++ b/src/main/php/scriptlet/Preference.class.php
@@ -22,7 +22,7 @@
  *
  * @test     xp://scriptlet.unittest.PreferenceTest
  */
-class Preference extends \lang\Object {
+class Preference {
   protected $list= [];
 
   /**

--- a/src/main/php/scriptlet/ScriptletOutputStream.class.php
+++ b/src/main/php/scriptlet/ScriptletOutputStream.class.php
@@ -5,7 +5,7 @@
  *
  * @see  xp://scriptlet.Reponse#out
  */
-class ScriptletOutputStream extends \lang\Object implements \io\streams\OutputStream {
+class ScriptletOutputStream implements \io\streams\OutputStream {
   protected $response;
 
   /**

--- a/src/main/php/scriptlet/xml/portlet/AbstractPortlet.class.php
+++ b/src/main/php/scriptlet/xml/portlet/AbstractPortlet.class.php
@@ -1,14 +1,12 @@
 <?php namespace scriptlet\xml\portlet;
 
-
-
 /**
  * Abstract portlet
  *
  * @see      xp://scriptlet.xml.portlet.Portlet
  * @purpose  Abstract base class
  */
-class AbstractPortlet extends \lang\Object implements Portlet {
+class AbstractPortlet implements Portlet {
   public
     $name       = '',
     $properties = null,
@@ -20,7 +18,7 @@ class AbstractPortlet extends \lang\Object implements Portlet {
    *
    */
   public function __construct() {
-    $this->setName(substr($this->getClass()->getSimpleName(), 0, -1* strlen('Portlet')));
+    $this->setName(substr(typeof($this)->getSimpleName(), 0, -1* strlen('Portlet')));
   }
 
   /**

--- a/src/main/php/scriptlet/xml/portlet/PortletContainer.class.php
+++ b/src/main/php/scriptlet/xml/portlet/PortletContainer.class.php
@@ -7,7 +7,7 @@
  *
  * @purpose  Container class
  */
-class PortletContainer extends \lang\Object {
+class PortletContainer {
   public
     $portlets= [];
 

--- a/src/main/php/scriptlet/xml/portlet/RunData.class.php
+++ b/src/main/php/scriptlet/xml/portlet/RunData.class.php
@@ -6,7 +6,7 @@
  * @see      xp://scriptlet.xml.portlet.Portlet
  * @purpose  purpose
  */
-class RunData extends \lang\Object {
+class RunData {
   public
     $request  = null,
     $context  = null;

--- a/src/main/php/scriptlet/xml/workflow/AbstractHandler.class.php
+++ b/src/main/php/scriptlet/xml/workflow/AbstractHandler.class.php
@@ -2,9 +2,8 @@
 
 use util\log\Traceable;
 
-
 // Handler stati
-  define('HANDLER_SETUP',       'setup');
+define('HANDLER_SETUP',       'setup');
 define('HANDLER_FAILED',      'failed');
 define('HANDLER_INITIALIZED', 'initialized');
 define('HANDLER_ERRORS',      'errors');
@@ -13,7 +12,7 @@ define('HANDLER_RELOADED',    'reloaded');
 define('HANDLER_CANCELLED',   'cancelled');
 
 // Value storages
-  define('HVAL_PERSISTENT',  0x0000);
+define('HVAL_PERSISTENT',  0x0000);
 define('HVAL_FORMPARAM',   0x0001);
 
 /**
@@ -22,7 +21,7 @@ define('HVAL_FORMPARAM',   0x0001);
  * @see      xp://scriptlet.xml.workflow.AbstractState#addHandler
  * @purpose  Base class
  */
-class AbstractHandler extends \lang\Object implements Traceable {
+class AbstractHandler implements Traceable {
   public
     $cat              = null,
     $wrapper          = null,
@@ -37,7 +36,7 @@ class AbstractHandler extends \lang\Object implements Traceable {
    *
    */
   public function __construct() {
-    $this->name= strtolower($this->getClass()->getSimpleName());
+    $this->name= strtolower(typeof($this)->getSimpleName());
   }
 
   /**

--- a/src/main/php/scriptlet/xml/workflow/AbstractState.class.php
+++ b/src/main/php/scriptlet/xml/workflow/AbstractState.class.php
@@ -9,7 +9,7 @@ use util\log\Traceable;
  * @see      xp://scriptlet.xml.workflow.AbstractXMLScriptlet
  * @purpose  Base class
  */
-class AbstractState extends \lang\Object implements Traceable {
+class AbstractState implements Traceable {
   public
     $cat      = null,
     $handlers = [];

--- a/src/main/php/scriptlet/xml/workflow/Context.class.php
+++ b/src/main/php/scriptlet/xml/workflow/Context.class.php
@@ -5,7 +5,7 @@
  *
  * @purpose  Context
  */
-class Context extends \lang\Object {
+class Context {
   public
     $_changed  = false;
 

--- a/src/main/php/scriptlet/xml/workflow/FileData.class.php
+++ b/src/main/php/scriptlet/xml/workflow/FileData.class.php
@@ -8,7 +8,7 @@ use io\File;
  *
  * @purpose  Wrapper
  */
-class FileData extends \lang\Object {
+class FileData {
   public
     $name = '',
     $type = '',

--- a/src/main/php/scriptlet/xml/workflow/Wrapper.class.php
+++ b/src/main/php/scriptlet/xml/workflow/Wrapper.class.php
@@ -22,7 +22,7 @@ define('PARAM_VALUES',     'values');
  * @test     xp://scriptlet.unittest.workflow.WrapperTest
  * @purpose  Base class
  */
-class Wrapper extends \lang\Object {
+class Wrapper {
   const
     OCCURRENCE_UNDEFINED  = 0x0000,
     OCCURRENCE_OPTIONAL   = 0x0001,

--- a/src/main/php/scriptlet/xml/workflow/casters/ParamCaster.class.php
+++ b/src/main/php/scriptlet/xml/workflow/casters/ParamCaster.class.php
@@ -5,7 +5,7 @@
  *
  * @purpose  Abstract base class
  */
-abstract class ParamCaster extends \lang\Object {
+abstract class ParamCaster {
 
   /**
    * Cast a given value

--- a/src/main/php/scriptlet/xml/workflow/casters/ToDate.class.php
+++ b/src/main/php/scriptlet/xml/workflow/casters/ToDate.class.php
@@ -1,7 +1,7 @@
 <?php namespace scriptlet\xml\workflow\casters;
 
 use util\Date;
-
+use lang\IllegalArgumentException;
 
 /**
  * Casts given values to date objects
@@ -10,42 +10,6 @@ use util\Date;
  * @purpose   Caster
  */
 class ToDate extends ParamCaster {
-  protected static $parse= 'date_parse';
-
-  static function __static() {
-    $p= date_parse('Feb 31');
-    if (0 === $p['warning_count']) {
-      self::$parse= [__CLASS__, 'parse'];
-    }
-  }
-  
-  /**
-   * Parse a date and verify number of days in month. Workaround for
-   * broken PHP versions that consider 31 a valid day in February! 
-   *
-   * Note: This method is called by castValue() only if PHP is 
-   * actually broken - a test in the static initializer determines
-   * this!
-   *
-   * @see     php://date_parse
-   * @param   string v
-   * @return  var
-   */
-  protected static function parse($v) {
-    static $dim= [
-      false => [-1, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31], 
-      true  => [-1, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-    ];
-
-    $p= date_parse($v);
-    if ($p['warning_count'] > 0 || $p['error_count']) return $v;
-    
-    // Date parser says it's OK, now verify # of days by looking
-    // at days in month table (take leap years into consideration!)
-    $l= $p['year'] % 400 == 0 || ($p['year'] > 1582 && $p['year'] % 100 == 0 ? false : $p['year'] % 4 == 0);
-    if ($p['day'] > $dim[$l][$p['month']]) $p['warning_count']++;
-    return $p;
-  }
 
   /**
    * Cast a given value
@@ -59,7 +23,7 @@ class ToDate extends ParamCaster {
     foreach ($value as $k => $v) {
       if ('' === $v) return 'empty';
       
-      $pv= call_user_func(self::$parse, $v);
+      $pv= date_parse($v);
       if (
         !is_int($pv['year']) ||
         !is_int($pv['month']) ||
@@ -72,7 +36,7 @@ class ToDate extends ParamCaster {
       
       try {
         $date= Date::create($pv['year'], $pv['month'], $pv['day'], $pv['hour'], $pv['minute'], $pv['second']);
-      } catch (\lang\IllegalArgumentException $e) {
+      } catch (IllegalArgumentException $e) {
         return $e->getMessage();
       }
 

--- a/src/main/php/scriptlet/xml/workflow/checkers/ParamChecker.class.php
+++ b/src/main/php/scriptlet/xml/workflow/checkers/ParamChecker.class.php
@@ -5,7 +5,7 @@
  *
  * @purpose  Abstract base class
  */
-abstract class ParamChecker extends \lang\Object {
+abstract class ParamChecker {
 
   /**
    * Check a given value

--- a/src/main/php/xp/scriptlet/AbstractUrlHandler.class.php
+++ b/src/main/php/xp/scriptlet/AbstractUrlHandler.class.php
@@ -5,7 +5,7 @@ use peer\Socket;
 /**
  * Base class for all URL handlers
  */
-abstract class AbstractUrlHandler extends \lang\Object {
+abstract class AbstractUrlHandler {
 
   /**
    * Send a HTTP header message
@@ -35,7 +35,7 @@ abstract class AbstractUrlHandler extends \lang\Object {
    * @param   string reason the reason
    */
   protected function sendErrorMessage(Socket $socket, $sc, $message, $reason) {
-    $package= $this->getClass()->getPackage();
+    $package= typeof($this)->getPackage();
     $errorPage= ($package->providesResource('error'.$sc.'.html')
       ? $package->getResource('error'.$sc.'.html')
       : $package->getResource('error500.html')

--- a/src/main/php/xp/scriptlet/BasedOnWebroot.class.php
+++ b/src/main/php/xp/scriptlet/BasedOnWebroot.class.php
@@ -11,7 +11,7 @@ use io\Path;
  *
  * @see   xp://xp.scriptlet.WebApplication
  */
-class BasedOnWebroot extends \lang\Object implements WebLayout {
+class BasedOnWebroot implements WebLayout {
   private $webroot, $config;
   private $layout= null;
 

--- a/src/main/php/xp/scriptlet/Develop.class.php
+++ b/src/main/php/xp/scriptlet/Develop.class.php
@@ -12,7 +12,7 @@ use lang\archive\ArchiveClassLoader;
  *
  * @see   http://php.net/manual/en/features.commandline.webserver.php
  */
-class Develop extends \lang\Object {
+class Develop {
   private $host, $port, $url;
   
   /**

--- a/src/main/php/xp/scriptlet/HttpProtocol.class.php
+++ b/src/main/php/xp/scriptlet/HttpProtocol.class.php
@@ -7,7 +7,7 @@ use peer\Socket;
 /**
  * HTTP protocol implementation
  */
-class HttpProtocol extends \lang\Object implements \peer\server\ServerProtocol {
+class HttpProtocol implements \peer\server\ServerProtocol {
   protected $handlers = [];
   private $logging;
   public $server = null;

--- a/src/main/php/xp/scriptlet/Inspect.class.php
+++ b/src/main/php/xp/scriptlet/Inspect.class.php
@@ -6,7 +6,7 @@ use util\cmd\Console;
 /**
  * Inspect scriptlet coniguration
  */
-class Inspect extends \lang\Object {
+class Inspect {
 
   /**
    * Entry point method. Gets passed the following arguments from "xpws -i":

--- a/src/main/php/xp/scriptlet/Runner.class.php
+++ b/src/main/php/xp/scriptlet/Runner.class.php
@@ -19,7 +19,7 @@ new import('lang.ResourceProvider');
  *
  * @test   xp://scriptlet.unittest.RunnerTest
  */
-class Runner extends \lang\Object {
+class Runner {
   protected
     $webroot    = null,
     $profile    = null,
@@ -303,7 +303,7 @@ class Runner extends \lang\Object {
    * @return  scriptlet.HttpScriptletResponse
    */
   protected function error($response, \lang\Throwable $t, $status, $trace) {
-    $package= $this->getClass()->getPackage();
+    $package= typeof($this)->getPackage();
     $errorPage= $package->getResource($package->providesResource('error'.$status.'.html')
       ? 'error'.$status.'.html'
       : 'error500.html'

--- a/src/main/php/xp/scriptlet/ServeDocumentRootStatically.class.php
+++ b/src/main/php/xp/scriptlet/ServeDocumentRootStatically.class.php
@@ -5,7 +5,7 @@
  *
  * @see   xp://xp.scriptlet.WebApplication
  */
-class ServeDocumentRootStatically extends \lang\Object implements WebLayout {
+class ServeDocumentRootStatically implements WebLayout {
 
   /**
    * Gets all mapped applications

--- a/src/main/php/xp/scriptlet/SingleScriptlet.class.php
+++ b/src/main/php/xp/scriptlet/SingleScriptlet.class.php
@@ -5,7 +5,7 @@
  *
  * @see   xp://xp.scriptlet.WebApplication
  */
-class SingleScriptlet extends \lang\Object implements WebLayout {
+class SingleScriptlet implements WebLayout {
   private $scriptlet, $config;
 
   /**

--- a/src/main/php/xp/scriptlet/Source.class.php
+++ b/src/main/php/xp/scriptlet/Source.class.php
@@ -13,7 +13,7 @@ use lang\ClassLoadingException;
  *
  * @test  xp://scriptlet.unittest.SourceTest
  */
-class Source extends \lang\Object {
+class Source {
   private $layout;
 
   /**

--- a/src/main/php/xp/scriptlet/Standalone.class.php
+++ b/src/main/php/xp/scriptlet/Standalone.class.php
@@ -7,7 +7,7 @@ use util\ResourcePropertySource;
 use util\FilesystemPropertySource;
 use rdbms\ConnectionManager;
 
-abstract class Standalone extends \lang\Object {
+abstract class Standalone {
   private $server, $url;
 
   public function __construct($server, $url) {

--- a/src/main/php/xp/scriptlet/Usage.class.php
+++ b/src/main/php/xp/scriptlet/Usage.class.php
@@ -3,7 +3,7 @@
 /**
  * Scriptlet usage
  */
-class Usage extends \lang\Object {
+class Usage {
 
   /**
    * Entry point method

--- a/src/main/php/xp/scriptlet/WebApplication.class.php
+++ b/src/main/php/xp/scriptlet/WebApplication.class.php
@@ -12,7 +12,7 @@ use lang\IllegalArgumentException;
  * @see      xp://xp.scriptlet.WebDebug
  * @see      xp://xp.scriptlet.Runner
  */
-class WebApplication extends \lang\Object {
+class WebApplication {
   protected $name;
   protected $config = null;
   protected $scriptlet = null;

--- a/src/main/php/xp/scriptlet/WebConfiguration.class.php
+++ b/src/main/php/xp/scriptlet/WebConfiguration.class.php
@@ -9,7 +9,7 @@ use lang\IllegalStateException;
  * @see   xp://xp.scriptlet.WebApplication
  * @test  xp://scriptlet.unittest.WebConfigurationTest
  */
-class WebConfiguration extends \lang\Object implements WebLayout {
+class WebConfiguration implements WebLayout {
   const INI = 'web.ini';
 
   private $prop, $config;

--- a/src/main/php/xp/scriptlet/WebDebug.class.php
+++ b/src/main/php/xp/scriptlet/WebDebug.class.php
@@ -5,7 +5,7 @@
  *
  * @see    xp://xp.scriptlet.WebApplication#setDebug
  */
-abstract class WebDebug extends \lang\Object {
+abstract class WebDebug {
   const
     NONE        = 0x0000,
     XML         = 0x0001,

--- a/src/test/php/scriptlet/unittest/workflow/WorkflowApiTest.class.php
+++ b/src/test/php/scriptlet/unittest/workflow/WorkflowApiTest.class.php
@@ -20,7 +20,7 @@ class WorkflowApiTest extends TestCase {
    *
    */
   public function setUp() {
-    $this->scriptlet= new AbstractXMLScriptlet($this->getClass()->getPackage()->getName());
+    $this->scriptlet= new AbstractXMLScriptlet(typeof($this)->getPackage()->getName());
     $this->scriptlet->init();
   }
 


### PR DESCRIPTION
This pull request makes this library compatible with XP9 and the following upcoming versions:

* [x] xp-framework/http [9.0](https://github.com/xp-framework/http/releases/tag/v9.0.0)+ 
* [x] xp-framework/xml [9.0](https://github.com/xp-framework/xml/releases/tag/v9.0.0)+ 
* [x] xp-framework/rdbms [10.0](https://github.com/xp-framework/rdbms/releases/tag/v10.0.0)+
* [x] xp-framework/mail [8.0](https://github.com/xp-framework/mail/releases/tag/v8.0.0)+ 
* [x] xp-framework/logging [8.0](https://github.com/xp-framework/logging/releases/tag/v8.0.0)+
* [x] xp-framework/networking [9.0](https://github.com/xp-framework/networking/releases/tag/v9.0.0)+ 
* [x] xp-framework/unittest [9.0](https://github.com/xp-framework/unittest/releases/tag/v9.0.0)+ 