### PR TITLE
Allows to cancel further handling of state after setup

### DIFF
--- a/src/main/php/scriptlet/xml/workflow/AbstractXMLScriptlet.class.php
+++ b/src/main/php/scriptlet/xml/workflow/AbstractXMLScriptlet.class.php
@@ -125,7 +125,13 @@ class AbstractXMLScriptlet extends XMLScriptlet {
     
     // Call state's setup() method
     try {
-      $request->state->setup($request, $response, $context);
+
+      // Call state's setup() method. In case it returns FALSE, the
+      // state's process() and context's insertStatus() method will not be called. 
+      // This, for example, is useful when setup() wants to send a redirect.
+      if ($request->state->setup($request, $response, $context) === false) {
+        return false;
+      }
     } catch (\lang\IllegalStateException $e) {
       throw new \scriptlet\ScriptletException($e->getMessage(), HttpConstants::STATUS_INTERNAL_SERVER_ERROR, $e);
     } catch (\lang\IllegalArgumentException $e) {

--- a/src/test/php/scriptlet/unittest/workflow/WorkflowApiTest.class.php
+++ b/src/test/php/scriptlet/unittest/workflow/WorkflowApiTest.class.php
@@ -130,4 +130,27 @@ class WorkflowApiTest extends TestCase {
       $this->assertInstanceOf('lang.IllegalArgumentException', $expected->getCause());
     }
   }
+
+  #[@test]
+  public function cancelFurtherProcessingInSetup() {
+    $request= new MockRequest($this->scriptlet->package, ucfirst($this->name), '{
+      public $called= [
+        "setup" => false,
+        "process" => false
+      ];
+      
+      public function setup($request, $response, $context) {
+        parent::setup($request, $response, $context);
+        $this->called["setup"]= TRUE;
+        return false;
+      }
+
+      public function process($request, $response, $context) {
+        $this->called["process"]= TRUE;
+      }
+    }');
+    $this->process($request);      
+    $this->assertTrue($request->state->called['setup']);
+    $this->assertFalse($request->state->called['process']);
+  }
 }


### PR DESCRIPTION
If the setup method returns "false" all further handling of this state is cancele.
This is helpful if you for example want to do a redirect in the setup function.